### PR TITLE
ci: Pin sonar version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,7 @@ node {
                         }
 
                         sh """
-                            mvn -f kura/pom.xml org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+                            mvn -f kura/pom.xml org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
                                 -Dmaven.test.failure.ignore=true \
                                 -Dsonar.organization=eclipse \
                                 -Dsonar.host.url=${SONAR_HOST_URL} \


### PR DESCRIPTION
This pull request makes a small change to the `Jenkinsfile` to specify a particular version of the Sonar Maven plugin during the build process. This ensures consistent and predictable static code analysis results. This modification is needed by [1].

* The Maven command now explicitly uses version `5.6.0.6792` of the `sonar-maven-plugin` instead of relying on the default version.

[1] https://community.sonarsource.com/t/retiring-the-magic-sonar-sonar-shorthand-of-the-sonarscanner-for-maven/179815