### PR TITLE
fix: missing javax imports

### DIFF
--- a/kura/org.eclipse.kura.cloud.base.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.cloud.base.provider/META-INF/MANIFEST.MF
@@ -31,6 +31,8 @@ Import-Package: org.eclipse.kura;version="[1.0,2.0)",
  org.osgi.service.event;version="1.4.0",
  org.osgi.util.tracker;version="1.5.0",
  org.quartz;version="2.3.2",
- org.slf4j;version="1.6.4"
+ org.slf4j;version="1.6.4",
+ javax.net,
+ javax.net.ssl
 Bundle-ClassPath: .,
  lib/org.eclipse.paho.client.mqttv3-1.2.1.k2.jar

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Import-Package: com.google.gson;version="[2.7,3.0)",
  org.osgi.service.component;version="1.2.0",
  org.osgi.service.event;version="1.3.1",
  org.osgi.util.tracker;version="[1.5,2.0)",
- org.slf4j;version="1.7.36"
+ org.slf4j;version="1.7.36",
+ javax.net
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml
 Bundle-Vendor: Eclipse Kura

--- a/kura/org.eclipse.kura.core.keystore/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core.keystore/META-INF/MANIFEST.MF
@@ -40,7 +40,9 @@ Import-Package: com.eclipsesource.json;version="0.9.5",
  org.osgi.service.event;version="1.4.0",
  org.osgi.service.useradmin;version="1.1.0",
  org.osgi.util.tracker;version="1.5.2",
- org.slf4j;version="1.7.32"
+ org.slf4j;version="1.7.32",
+ javax.net.ssl,
+ javax.security.auth.x500
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.kura.core.keystore.util;version="1.1.0"

--- a/kura/org.eclipse.kura.db.h2db.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.db.h2db.provider/META-INF/MANIFEST.MF
@@ -30,4 +30,5 @@ Import-Package: org.eclipse.kura;version="[1.7,2.0)",
  org.h2.tools;version="2.4.240",
  org.osgi.framework;version="1.10.0",
  org.osgi.service.component;version="1.4.0",
- org.slf4j;version="1.7.32"
+ org.slf4j;version="1.7.32",
+ javax.sql

--- a/kura/org.eclipse.kura.db.sqlite.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.db.sqlite.provider/META-INF/MANIFEST.MF
@@ -35,4 +35,5 @@ Import-Package: com.zaxxer.hikari;version="2.7.9",
  org.sqlite.javax;version="3.39.3.0",
  org.sqlite.jdbc3;version="3.39.3.0",
  org.sqlite.jdbc4;version="3.39.3.0",
- org.sqlite.util;version="3.39.3.0"
+ org.sqlite.util;version="3.39.3.0",
+ javax.sql

--- a/kura/org.eclipse.kura.http.server.manager/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.http.server.manager/META-INF/MANIFEST.MF
@@ -26,5 +26,6 @@ Import-Package: jakarta.servlet;version="5.0.0",
  org.osgi.framework;version="1.8.0",
  org.osgi.service.component;version="1.3.0",
  org.osgi.service.event;version="1.4.0",
- org.slf4j;version="1.7.21"
+ org.slf4j;version="1.7.21",
+ javax.net.ssl
 Require-Bundle: org.apache.felix.http.bridge;bundle-version="5.1.8"

--- a/kura/org.eclipse.kura.rest.keystore.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.rest.keystore.provider/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Import-Package: com.google.gson;version="2.7.0",
  org.osgi.service.component;version="1.2.0",
  org.osgi.service.useradmin;version="1.1.0",
  org.osgi.util.tracker;version="1.5.2",
- org.slf4j;version="1.7.36"
+ org.slf4j;version="1.7.36",
+ javax.security.auth.x500
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=21))"
 Bundle-ClassPath: .

--- a/kura/org.eclipse.kura.rest.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.rest.provider/META-INF/MANIFEST.MF
@@ -27,7 +27,8 @@ Import-Package: com.google.gson;version="2.9.0",
  org.osgi.service.cm;version="1.6.0",
  org.osgi.service.component;version="1.5.0",
  org.osgi.util.tracker;version="1.5.2",
- org.slf4j;version="1.7.21"
+ org.slf4j;version="1.7.21",
+ javax.naming.ldap
 Require-Bundle: org.eclipse.osgitech.rest.servlet.whiteboard;bundle-version="1.2.3"
 Export-Package: org.eclipse.kura.rest.auth;version="1.0.0",
  org.eclipse.kura.rest.utils;version="1.0.0"

--- a/kura/test-util/org.eclipse.kura.core.testutil/META-INF/MANIFEST.MF
+++ b/kura/test-util/org.eclipse.kura.core.testutil/META-INF/MANIFEST.MF
@@ -43,7 +43,8 @@ Import-Package: com.eclipsesource.json;version="0.9.5",
  org.osgi.framework;version="1.10.0",
  org.osgi.service.event;version="1.4.0",
  org.osgi.util.tracker;version="1.5.2",
- org.slf4j;version="1.6.4"
+ org.slf4j;version="1.6.4",
+ javax.net.ssl
 Bundle-ActivationPolicy: lazy
 Comment: Unit testing utilities
 Export-Package: org.eclipse.kura.core.testutil;version="1.0.0",


### PR DESCRIPTION
Some of the bundles were missing the `javax` imports, which are normally provided by the JRE. Not having them can cause issues when running integration tests using the BND archetype. This change should not affect the normal behaviour at runtime.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.