### PR TITLE
chore: add Kura 5.6.2 release notes

### DIFF
--- a/kura/distrib/RELEASE_NOTES.txt
+++ b/kura/distrib/RELEASE_NOTES.txt
@@ -1,14 +1,26 @@
 Eclipse Kura - 5.6.2 - May 2026
 -------------------------------------------------------------------------------------------------
 Description:
-[TODO]
+This patch release of Eclipse Kura, compatible with Java 8 and OSGi R7 includes:
+  - Security updates to address vulnerabilities in dependencies (for example Jetty to 9.4.58.v20250814)
+  - Added support for multiple GPIO pin listeners in the libgpiod integration
+  - Improved handling of X-Forwarded-For header for audit logging
 
 
 Features:
   * f961ca425e - [linux.gpio.libgpiod] Added support to multiple pin listeners (#6197) (Pierantonio Merlino)
 
 Target Environments:
-[TODO]
+ Kura is released as pre-compiled binary installers for the following platforms:
+  * Intel Up Squared board running Ubuntu 20.04 (Kura networking)
+  * Nvidia Jetson Nano board running Ubuntu 18 (Kura networking)
+  * Generic Debian Package for x86_64 (NetworkManager)
+  * Generic Debian Package for arm32 (NetworkManager)
+  * Generic Debian Package for arm64 (NetworkManager)
+ Kura no longer provides a dedicated installer for the following platforms, but support is still provided through the Generic Debian Packages (see https://github.com/eclipse/kura/discussions/5224):
+  * Raspberry Pi 2/3/4 based on Raspberry Pi OS (32 bits)
+  * Raspberry Pi 3/4 based on 64 bits OS
+ Kura is also available as a pre-built Docker container for Ubi 8 and Alpine
 
 Bug Fixes:
   * 35c65ff6d9 - Correctly handle X-Forwarded-For header for audit logging [backport release-5.6.0] (#6218) (Matteo Maiero)
@@ -17,7 +29,66 @@ Bug Fixes:
   * 255b68934d - Fixed placeholder handling for password defaults [backport release-5.6.0] (#6189) (nicolatimeus)
 
 Known Issues:
-[TODO]
+  * On certain systems the IPv6 rt match module (-m rt) is not available, causing Kura to fail when applying IPv6 mangle table rules related to Routing Header Type 0 filtering.
+    When this occurs, IPv6 Routing Header Type 0 packets will not be explicitly dropped on affected systems.
+  * During a wifi scan, some access points with the WPA/WPA2 wifi security are recognized as WPA.
+  * On devices with Ubuntu 20.04, the DHCP server provided by isc-dhcp-server may not assign an IP address to the clients. Use dnsmasq instead.
+  * Different GNSS Type retrieved from different Position Providers (see #5409 for details)
+  * Snapshot rollback operation may fail processing factory component configurations.
+  * The firewall rule applied by the network threat manager that block uncommon TCP MSS values is not applied in the Nvidia Jetson Nano.
+  * When the IPv6 network threat manager is disabled, the filtering on TCP fragments is disabled only after a reboot.
+  * The republish.mqtt.birth.cert.on.modem.detect property in the CloudService configuration is not supported for devices that use NetworkManager. The property value is ignored.
+  * When dnsmasq is used as DHCP server, only one file is used to store the leases.
+  * When dnsmasq is used as DHCP server, the DHCP List field in the DHCP and NAT tab shows the leases for all the interfaces.
+  * The system reboot command cannot be issued even with a privileged user in Debian Bookworm due to an OS issue related to the CAP_SYS_BOOT capability.
+  * The Wi-Fi AP scanning may fail in Debian Bookworm on the first scanning attempt in the specific Raspberry PI profile. A forced rescan can succeed and properly display the available APs.
+  * The nvidia-jetson-nano installer disables FAN protocol support due to compatibility issues (see #4593)
+  * The nvidia-jetson-nano doesn't support the Unprivileged Command Service (see #3598)
+  * isc-dhcp-server fails upon first Kura installation on Raspberry Pi Bullseye. This is due to how the isc-dhcp-server installer package is
+    built and run immediately after installation.
+  * An update to the sslmanagerservice where the pid of the keystoreservice is updated can lead to an error in the following reconnection.
+    The issue impact is limited, if the dataservice reconnect option is enabled.
+  * The implementation of the CryptoService performs encryption using a
+    password that is hardcoded and published.
+  * Modem: Ublox Lisa U201 may not be able to establish PPP connection when CHAP/PAP authentication is required.
+  * WiFi on Raspberry Pi 2 has only been tested with WiPi WiFi Dongle (Realink RT5370 chipset) and official Pi USB WiFi Dongle (Broadcom BCM43143 chipset).
+    AccessPoint WiFi mode not working for Broadcom chipset.
+  * Hardware watchdog: not implemented on all platforms
+  * Only one WAN interface is currently supported with old networking. A warning in displayed
+    in the WEB UI if the user attempts to enable more than one WAN interface
+  * #4212: Wrong order of BIRTH/APPLICATION certificates for custom APP IDs registration
+  * #3972: Topic name validation: issue with names containing "//" (Cloud Subscriber)
+  * #4141: Sometimes user is not logged in after changing password
+  * #3796: Server manager does not close properly
+  * #3211: Kura Docker | Bluetooth error in log during starting service
+  * #3005: Kura Gets Stuck in Loading View if Services Clicked Too Fast
+  * #2843: Access Banner Content All in One Line
+  * #2747: No Spacing Between "Wire Components" and Error in Wire Graph
+  * #2728: WireGraph Component Description Windows Too Wide
+  * #2725: Different Pop-up Windows for Warnings
+  * #2702: Error Message For Long Item Names Not Displayed Properly
+  * #2696: Component Name Inteferes With Wire Graph Border
+  * #2695: Component Names in Wires Not Limited
+  * #2410: Deployment handler and URLs with many query parameters
+  * #2038: [Kura 3.2.0 QA] Package uninstallation log
+  * #1993: Search Domains Are Not Supported
+  * #1663: Authentication Issue with Deploy V2
+  * #1572: serial modbus has errors on some hardware
+  * #1529: OSGI console is not redirected to Eclipse IDE with Kura 3.0
+  * #1161: Incorrectly configuring a component can be irreversable.
+  * #1128: [Kura 3.0.0 M1 QA] Unable to delete manually added CamelFactory services
+  * #1016: ConfigurationServiceImpl creates duplicate instances
+  * #797:  Design of ServiceUtil is broken
+  * #771:  Web UI fails with INTERNAL_ERROR when WireHelperService is not registered
+  * #654:  Clean up static initialization around "modem" functionality
+  * #645:  Clean up internal dependencies in Kura
+  * #522:  [Net] Modem monitor should monitor interfaces, not modems
+  * #486:  Build environment broken on Windows
+  * #406:  Replace System.get* with calls to SystemService.getProperties
+  * #329:  [DEPLOY-V2] Review/refactoring needed
+  * #297:  [Status led] What connection instance controls the status led?
+  * #253:  Check if bundle contexes correctly unget services after invoking getService
+  * #222:  CloudConnectionStatusServiceImpl does not cancel workers on component deactivation
 
 Changelog:
   * 1ef6e8c141 - chore: automated uptick to 5.6.2 (#6232) (eclipse-kura-bot)

--- a/kura/distrib/RELEASE_NOTES.txt
+++ b/kura/distrib/RELEASE_NOTES.txt
@@ -1,229 +1,36 @@
-Eclipse Kura - 5.6.1 - November 2025
+Eclipse Kura - 5.6.2 - May 2026
 -------------------------------------------------------------------------------------------------
 Description:
-This patch release of Eclipse Kura, compatible with Java 8 and OSGi R7 includes:
-  - Dependency updates to resolve CVEs (for example Netty to 4.1.121.Final and docker-java to 3.5.3) 
-  - Important bug fixes to UI and networking components
-  - Default configuration aligned with RED-DA (Radio Equipment Directive Delegated Act) requirements
-  - Improved GPIO support with a new libgpiod integration.
+[TODO]
 
 
 Features:
-  * 868fe32125 - Added jul.to.sl4j bridge (#6102) (Salvatore Coppola)
-  * 66fea3a0ba - [network.threat.manager] add IPv6 ICMPv6 filter rules for flooding protection [release-5.6.0] (#6075) (Matteo Maiero)
-  * e121df3ecf - [RED-DA] remove appadmin and netadmin from emulator [backport release-5.6.0] (#6050) (Pierantonio Merlino)
-  * ac4fb9a6f6 - [RED-DA] remove `appadmin` and `netadmin` from snapshot_0 [backport release-5.6.0] (#6045) (Pierantonio Merlino)
-  * bbea586e52 - [RED-DA] default enable flooding protection [backport release 5.6.0] (#6041) (Matteo Maiero)
-  * 90767eccca - [RED-DA] new password strength policy [backport release-5.6.0] (#6038) (Matteo Maiero)
-  * 8ea2e7754b - [RED-DA] enable access banner by default [backport release-5.6.0] (#6037) (Matteo Maiero)
-  * 5f0822acdb - [linux.gpio] Libgpiod v2 implementation (#6002) (Pierantonio Merlino)
-  * 17086209fb - [linux.gpio] Libgpiod V1.6.X implementation (#5986) (Pierantonio Merlino)
-  * 3f00ed7e54 - added MTU limits in webUI [backport release-5.6.0] (#5605) (eclipse-kura-bot)
+  * f961ca425e - [linux.gpio.libgpiod] Added support to multiple pin listeners (#6197) (Pierantonio Merlino)
 
 Target Environments:
- Kura is released as pre-compiled binary installers for the following platforms:
-  * Intel Up Squared board running Ubuntu 20.04 (Kura networking)
-  * Nvidia Jetson Nano board running Ubuntu 18 (Kura networking)
-  * Generic Debian Package for x86_64 (NetworkManager)
-  * Generic Debian Package for arm32 (NetworkManager)
-  * Generic Debian Package for arm64 (NetworkManager)
- Kura no longer provides a dedicated installer for the following platforms, but support is still provided through the Generic Debian Packages (see https://github.com/eclipse/kura/discussions/5224):
-  * Raspberry Pi 2/3/4 based on Raspberry Pi OS (32 bits)
-  * Raspberry Pi 3/4 based on 64 bits OS
- Kura is also available as a pre-built Docker container for Ubi 8 and Alpine
+[TODO]
 
 Bug Fixes:
-  * ee49b7c3f9 - Updated beanutils reference after dep name change (#6106) (Matteo Maiero)
-  * d95a6d3b13 - access point WEP password validation failure (#6092) (sfiorani)
-  * 1706193ac9 - Network failover configuration fixes [backport release-5.6.0] (#6087) (github-actions[bot])
-  * cba5b06c9a - Fixed container provider version [release-5.6.0] (#6086) (Matteo Maiero)
-  * 0c9e06e908 - Fixed wrong bluetooth.conf and wpa_supplicant.conf reference on Ubuntu 24.04 (MMaiero)
-  * 4f9203df1c - fixed firewall service variable replacement [release-5.6.0] (#6072) (Matteo Maiero)
-  * a8f97f759d - [web2] generic error when setting access point with no password [backport release-5.6.0] (#6054) (sfiorani)
-  * 201c9aa92c - Prominent alert on using default password for CryptoServiceImpl [backport release-5.6.0] (#6053) (nicolatimeus)
-  * a53272526d - Flooding protection version reference [backport release-5.6.0] (#6057) (Matteo Maiero)
-  * 9108400a8b - Allowed to get GPIO by name in CloudConnectionStatusService [backport release-5.6.0] (#6039) (nicolatimeus)
-  * ccd46ac565 - [linux.net] Allow outgoing ping while flooding protection is enabled [backport 5.6.0] (#6028) (Matteo Maiero)
-  * bb70adedbd - [distrib] disable systemd watchdog to allow kura managing it [backport-5.6] (#6027) (Marcello Rinaldo Martina)
-  * f7d91e0196 - [distrib] Fixed packages dir permissions [backport release-5.6.0] (#6018) (Salvatore Coppola)
-  * f609efd476 - [distrib] added polkitd, ntpdate, jre 17, jre 21 alternative deps [backport release-5.6] (#6007) (Marcello Rinaldo Martina)
-  * 8f6496b64b - fixed verifyCRL ignored by CRLManagerOptions.equals() [backport release-5.6.0] (#6012) (github-actions[bot])
-  * a8c4c987a4 - check existance of parameter in modem (#6001) (sfiorani)
-  * 7f2c266663 - Fixed KeystoreChangedEvent not posted in some scenarios [backport release-5.6.0] (#5997) (nicolatimeus)
-  * 410a0efdec - [core.configuration] make snapshot storage more resilient [backport 5.6.0] (#5991) (Matteo Maiero)
-  * 2916d45c79 - ipv6 firewall icmpv6 sources [Backport 5.6.0] (#5973) (Matteo Maiero)
-  * 57f4bb59ea - [distrib] update start level of `permission.cache.fix` (#5978) (Mattia Dal Ben)
-  * 9d45197c42 - manage log rotation via log4j [backport #5974] (#5975) (Mattia Dal Ben)
-  * b1b465e70b - [distrib] restore log output (#5976) (Mattia Dal Ben)
-  * e1c979c43e - [core.deployment] Configured SslManagerService is now correctly used by the Deployment agent [Backport release-5.6.0] (#5968) (Salvatore Coppola)
-  * 1856b9bdd6 - [ui] initialize unconfigured wireless interface to resolve NPE, fix channel selection on hardware tab, fix validation message on empty password [backport release-5.6.0] (#5956) (Marcello Rinaldo Martina)
-  * 8d78486364 - [equinox] Permission cache fix (#5966) (Salvatore Coppola)
-  * 11e7ebc54a - max number of log files not correctly enforced in high-volume logging circumstances [backport #5961] (#5962) (Mattia Dal Ben)
-  * 489f6ed952 - wifi 802 1x password field definition [backport] (#5947) (Matteo Maiero)
-  * 6e0948299d - [data-service] replace hardcoded documentation link with descriptive text [backport release-5.6.0] (#5948) (github-actions[bot])
-  * fbfa71fb58 - [web2] avoid password validation in 802.1x config for station mode (#5945) (Marcello Rinaldo Martina)
-  * f8e420df15 - Do not include router option if no nat [backport release-5.6.0] (#5753) (eclipse-kura-bot)
-  * f3733694f5 - [distrib] kura_install.sh is broken [backport release-5.6.0] (#5647) (eclipse-kura-bot)
-  * bf26d47a2f - release notes automation after Github executors update [backport release-5.6.0] (#5621) (eclipse-kura-bot)
-  * 3353d228cd - Extended log download timeframe. Improved messages. [backport release-5.6.0] (#5600) (eclipse-kura-bot)
-  * 8633fc1e3b - [web2] Fixed wireless mode selection [backport release-5.6.0] (#5590) (eclipse-kura-bot)
-  * dd1fde9c0f - correctly stopping gpsd thread [backport release-5.6.0] (#5588) (eclipse-kura-bot)
-  * a2a0047944 - Fixed IPv6 validation [backport release-5.6.0] (#5582) (eclipse-kura-bot)
-  * 56e5f7a096 - fixed loading of country code [backport release-5.6.0] (#5581) (eclipse-kura-bot)
-  * 025688e2e1 - Improved ordering of services list [backport release-5.6.0] (#5577) (eclipse-kura-bot)
-
-Target Platform Updates:
-  * 4d358a66d2 - bump commons-beanutils:commons-beanutils from 1.9.3 to 1.11.0 [backport release-5.6.0] (#6104) (Matteo Maiero)
-  * a263fa0236 - Updated jersey to 2.47 (#6100) (nicolatimeus)
-  * df0ee1988e - updated commons-lang3 to 3.19.0 [backport release-5.6.0] (#6061) (Marcello Rinaldo Martina)
-  * c79b800893 - adding dnsmasq leases file removal at uninstall (#6036) (sfiorani)
-  * 5d294471aa - add maven-clean-plugin configuration for lib directories (#5980) (Matteo Maiero)
-  * cdae814508 - update `kura_addons` URL [backport #5977] (#5979) (Mattia Dal Ben)
-  * d04ae54d64 - Update docker-java to 3.5.3 (#5881) [backport release-5.6.0]  (#5897) (Matteo Maiero)
-  * e2b1ea2344 - Upgraded netty to 4.1.121.Final [backport release-5.6.0] (#5823) (github-actions[bot])
-  * 6588b69988 - Upgraded netty to 4.1.118.Final [backport release-5.6.0] (#5739) (eclipse-kura-bot)
+  * 35c65ff6d9 - Correctly handle X-Forwarded-For header for audit logging [backport release-5.6.0] (#6218) (Matteo Maiero)
+  * a669473c20 - [linux.gpio.libgpiod] Fix GPIO events behavior in libgpiod v1 (#6184) (Pierantonio Merlino)
+  * f7456aca86 - Fixed password encryption in ConfigurationService.createFactoryConfiguration [backport release-5.6.0] (#6182) (nicolatimeus)
+  * 255b68934d - Fixed placeholder handling for password defaults [backport release-5.6.0] (#6189) (nicolatimeus)
 
 Known Issues:
-  * On certain systems the IPv6 rt match module (-m rt) is not available, causing Kura to fail when applying IPv6 mangle table rules related to Routing Header Type 0 filtering.
-    When this occurs, IPv6 Routing Header Type 0 packets will not be explicitly dropped on affected systems.
-  * During a wifi scan, some access points with the WPA/WPA2 wifi security are recognized as WPA.
-  * On devices with Ubuntu 20.04, the DHCP server provided by isc-dhcp-server may not assign an IP address to the clients. Use dnsmasq instead.
-  * Different GNSS Type retrieved from different Position Providers (see #5409 for details)
-  * Snapshot rollback operation may fail processing factory component configurations.
-  * The firewall rule applied by the network threat manager that block uncommon TCP MSS values is not applied in the Nvidia Jetson Nano.
-  * When the IPv6 network threat manager is disabled, the filtering on TCP fragments is disabled only after a reboot.
-  * The republish.mqtt.birth.cert.on.modem.detect property in the CloudService configuration is not supported for devices that use NetworkManager. The property value is ignored.
-  * When dnsmasq is used as DHCP server, only one file is used to store the leases.
-  * When dnsmasq is used as DHCP server, the DHCP List field in the DHCP and NAT tab shows the leases for all the interfaces.
-  * The system reboot command cannot be issued even with a privileged user in Debian Bookworm due to an OS issue related to the CAP_SYS_BOOT capability.
-  * The Wi-Fi AP scanning may fail in Debian Bookworm on the first scanning attempt in the specific Raspberry PI profile. A forced rescan can succeed and properly display the available APs.
-  * The nvidia-jetson-nano installer disables FAN protocol support due to compatibility issues (see #4593)
-  * The nvidia-jetson-nano doesn't support the Unprivileged Command Service (see #3598)
-  * isc-dhcp-server fails upon first Kura installation on Raspberry Pi Bullseye. This is due to how the isc-dhcp-server installer package is
-    built and run immediately after installation.
-  * An update to the sslmanagerservice where the pid of the keystoreservice is updated can lead to an error in the following reconnection.
-    The issue impact is limited, if the dataservice reconnect option is enabled.
-  * The implementation of the CryptoService performs encryption using a
-    password that is hardcoded and published.
-  * Modem: Ublox Lisa U201 may not be able to establish PPP connection when CHAP/PAP authentication is required.
-  * WiFi on Raspberry Pi 2 has only been tested with WiPi WiFi Dongle (Realink RT5370 chipset) and official Pi USB WiFi Dongle (Broadcom BCM43143 chipset).
-    AccessPoint WiFi mode not working for Broadcom chipset.
-  * Hardware watchdog: not implemented on all platforms
-  * Only one WAN interface is currently supported with old networking. A warning in displayed
-    in the WEB UI if the user attempts to enable more than one WAN interface
-  * #4212: Wrong order of BIRTH/APPLICATION certificates for custom APP IDs registration
-  * #3972: Topic name validation: issue with names containing "//" (Cloud Subscriber)
-  * #4141: Sometimes user is not logged in after changing password
-  * #3796: Server manager does not close properly
-  * #3211: Kura Docker | Bluetooth error in log during starting service
-  * #3005: Kura Gets Stuck in Loading View if Services Clicked Too Fast
-  * #2843: Access Banner Content All in One Line
-  * #2747: No Spacing Between "Wire Components" and Error in Wire Graph
-  * #2728: WireGraph Component Description Windows Too Wide
-  * #2725: Different Pop-up Windows for Warnings
-  * #2702: Error Message For Long Item Names Not Displayed Properly
-  * #2696: Component Name Inteferes With Wire Graph Border
-  * #2695: Component Names in Wires Not Limited
-  * #2410: Deployment handler and URLs with many query parameters
-  * #2038: [Kura 3.2.0 QA] Package uninstallation log
-  * #1993: Search Domains Are Not Supported
-  * #1663: Authentication Issue with Deploy V2
-  * #1572: serial modbus has errors on some hardware
-  * #1529: OSGI console is not redirected to Eclipse IDE with Kura 3.0
-  * #1161: Incorrectly configuring a component can be irreversable.
-  * #1128: [Kura 3.0.0 M1 QA] Unable to delete manually added CamelFactory services
-  * #1016: ConfigurationServiceImpl creates duplicate instances
-  * #797:  Design of ServiceUtil is broken
-  * #771:  Web UI fails with INTERNAL_ERROR when WireHelperService is not registered
-  * #654:  Clean up static initialization around "modem" functionality
-  * #645:  Clean up internal dependencies in Kura
-  * #522:  [Net] Modem monitor should monitor interfaces, not modems
-  * #486:  Build environment broken on Windows
-  * #406:  Replace System.get* with calls to SystemService.getProperties
-  * #329:  [DEPLOY-V2] Review/refactoring needed
-  * #297:  [Status led] What connection instance controls the status led?
-  * #253:  Check if bundle contexes correctly unget services after invoking getService
-  * #222:  CloudConnectionStatusServiceImpl does not cancel workers on component deactivation
+[TODO]
 
 Changelog:
-  * ee49b7c3f9 - fix: Updated beanutils reference after dep name change (#6106) (Matteo Maiero)
-  * 553408d9a8 - chore: add Kura 5.6.1 release notes (#6105) (eclipse-kura-bot)
-  * 4d358a66d2 - build(deps): bump commons-beanutils:commons-beanutils from 1.9.3 to 1.11.0 [backport release-5.6.0] (#6104) (Matteo Maiero)
-  * 868fe32125 - feat: Added jul.to.sl4j bridge (#6102) (Salvatore Coppola)
-  * a263fa0236 - build: Updated jersey to 2.47 (#6100) (nicolatimeus)
-  * cbc38753de - chore: add Kura 5.6.1 release notes (#6093) (sfiorani)
-  * d95a6d3b13 - fix: access point WEP password validation failure (#6092) (sfiorani)
-  * b91ac5df67 - chore: add Kura 5.6.1 release notes (#6088) (sfiorani)
-  * 1706193ac9 - fix: Network failover configuration fixes [backport release-5.6.0] (#6087) (github-actions[bot])
-  * cba5b06c9a - fix: Fixed container provider version [release-5.6.0] (#6086) (Matteo Maiero)
-  * 7415d4ef68 - docs(container.provider): Added info on container resource management [backport release-5.6.0] (#6085) (github-actions[bot])
-  * fce33ffcb8 - refactor(distrib): remove redundant else clause in find_dbus_config_path (#6074) (Matteo Maiero)
-  * 66fea3a0ba - feat(network.threat.manager): add IPv6 ICMPv6 filter rules for flooding protection [release-5.6.0] (#6075) (Matteo Maiero)
-  * eff5e0c6e8 - refactor: Extract duplicated dbus config path detection into reusable function (MMaiero)
-  * 263e1a89cd - Apply suggestion from @Copilot (Matteo Maiero)
-  * 0c9e06e908 - fix: Fixed wrong bluetooth.conf and wpa_supplicant.conf reference on Ubuntu 24.04 (MMaiero)
-  * 4f9203df1c - fix: fixed firewall service variable replacement [release-5.6.0] (#6072) (Matteo Maiero)
-  * 3f5e395d2f - chore: add Kura 5.6.1 release notes (#6069) (eclipse-kura-bot)
-  * d19fde34dd - chore(core.crypto): uptick core.crypto [release 5.6.0] (#6068) (sfiorani)
-  * 3cfdd41ca9 - chore: add Kura 5.6.1-SNAPSHOT release notes (#6067) (eclipse-kura-bot)
-  * 001e6094c6 - chore: automated uptick to 5.6.1 (#6060) (eclipse-kura-bot)
-  * a8f97f759d - fix(web2): generic error when setting access point with no password [backport release-5.6.0] (#6054) (sfiorani)
-  * 201c9aa92c - fix: Prominent alert on using default password for CryptoServiceImpl [backport release-5.6.0] (#6053) (nicolatimeus)
-  * df0ee1988e - build(deps): updated commons-lang3 to 3.19.0 [backport release-5.6.0] (#6061) (Marcello Rinaldo Martina)
-  * a53272526d - fix: Flooding protection version reference [backport release-5.6.0] (#6057) (Matteo Maiero)
-  * e121df3ecf - feat(RED-DA): remove appadmin and netadmin from emulator [backport release-5.6.0] (#6050) (Pierantonio Merlino)
-  * c79b800893 - build: adding dnsmasq leases file removal at uninstall (#6036) (sfiorani)
-  * ac4fb9a6f6 - feat(RED-DA): remove `appadmin` and `netadmin` from snapshot_0 [backport release-5.6.0] (#6045) (Pierantonio Merlino)
-  * bbea586e52 - feat(RED-DA): default enable flooding protection [backport release 5.6.0] (#6041) (Matteo Maiero)
-  * 35f5c79774 - docs(api): clarify ConfigurationPolicy.REQUIRED requirement for ConfigurableComponent [backport release-5.6.0] (#6040) (github-actions[bot])
-  * 9108400a8b - fix: Allowed to get GPIO by name in CloudConnectionStatusService [backport release-5.6.0] (#6039) (nicolatimeus)
-  * 90767eccca - feat(RED-DA): new password strength policy [backport release-5.6.0] (#6038) (Matteo Maiero)
-  * 8ea2e7754b - feat(RED-DA): enable access banner by default [backport release-5.6.0] (#6037) (Matteo Maiero)
-  * ccd46ac565 - fix(linux.net): Allow outgoing ping while flooding protection is enabled [backport 5.6.0] (#6028) (Matteo Maiero)
-  * 6fa92b114d - chore: Updated certificates for Eclipse Marketplace [backport release-5.6.0] (#6031) (Matteo Maiero)
-  * 1d1b5bd43c - refactor(distrib): align watchdog restore code in develop (#6030) (Marcello Rinaldo Martina)
-  * bb70adedbd - fix(distrib): disable systemd watchdog to allow kura managing it [backport-5.6] (#6027) (Marcello Rinaldo Martina)
-  * c96d898fe6 - chore: Changed UI labels to make them more understandable (#5614) [backport release-5.6.0] (#6021) (Matteo Maiero)
-  * f7d91e0196 - fix(distrib): Fixed packages dir permissions [backport release-5.6.0] (#6018) (Salvatore Coppola)
-  * 5f0822acdb - feat(linux.gpio): Libgpiod v2 implementation (#6002) (Pierantonio Merlino)
-  * 1391ff3a8b - chore: fix typo in ContainerOrchestrationServiceImpl log [backport release-5.6.0] (#6014) (github-actions[bot])
-  * a7c7deca59 - chore: Removed systemd-hostnamed disabling [backport-release-5.6.0] (#6017) (Salvatore Coppola)
-  * f609efd476 - fix(distrib): added polkitd, ntpdate, jre 17, jre 21 alternative deps [backport release-5.6] (#6007) (Marcello Rinaldo Martina)
-  * 17086209fb - feat(linux.gpio): Libgpiod V1.6.X implementation (#5986) (Pierantonio Merlino)
-  * 8f6496b64b - fix: fixed verifyCRL ignored by CRLManagerOptions.equals() [backport release-5.6.0] (#6012) (github-actions[bot])
-  * b1724048bb - chore: Updated netty bundles to 4.1.127 (#6008) (Pierantonio Merlino)
-  * a8c4c987a4 - fix: check existance of parameter in modem (#6001) (sfiorani)
-  * 7f2c266663 - fix: Fixed KeystoreChangedEvent not posted in some scenarios [backport release-5.6.0] (#5997) (nicolatimeus)
-  * 410a0efdec - fix(core.configuration): make snapshot storage more resilient [backport 5.6.0] (#5991) (Matteo Maiero)
-  * 2916d45c79 - fix: ipv6 firewall icmpv6 sources [Backport 5.6.0] (#5973) (Matteo Maiero)
-  * 57f4bb59ea - fix(distrib): update start level of `permission.cache.fix` (#5978) (Mattia Dal Ben)
-  * 5d294471aa - build(cloudconnection): add maven-clean-plugin configuration for lib directories (#5980) (Matteo Maiero)
-  * cdae814508 - build: update `kura_addons` URL [backport #5977] (#5979) (Mattia Dal Ben)
-  * 9d45197c42 - fix: manage log rotation via log4j [backport #5974] (#5975) (Mattia Dal Ben)
-  * b1b465e70b - fix(distrib): restore log output (#5976) (Mattia Dal Ben)
-  * e1c979c43e - fix(core.deployment): Configured SslManagerService is now correctly used by the Deployment agent [Backport release-5.6.0] (#5968) (Salvatore Coppola)
-  * 1856b9bdd6 - fix(ui): initialize unconfigured wireless interface to resolve NPE, fix channel selection on hardware tab, fix validation message on empty password [backport release-5.6.0] (#5956) (Marcello Rinaldo Martina)
-  * 8d78486364 - fix(equinox): Permission cache fix (#5966) (Salvatore Coppola)
-  * 11e7ebc54a - fix: max number of log files not correctly enforced in high-volume logging circumstances [backport #5961] (#5962) (Mattia Dal Ben)
-  * 489f6ed952 - fix: wifi 802 1x password field definition [backport] (#5947) (Matteo Maiero)
-  * 6e0948299d - fix(data-service): replace hardcoded documentation link with descriptive text [backport release-5.6.0] (#5948) (github-actions[bot])
-  * fbfa71fb58 - fix(web2): avoid password validation in 802.1x config for station mode (#5945) (Marcello Rinaldo Martina)
-  * 98366b11dd - test: fix failing CloudConnectionEndpointsTest.shouldConnectEndpoint [backport release-5.6.0] (#5930) (github-actions[bot])
-  * 7a16d49e4b - chore: Fixed dependencies and updated notice file (#5910) (Matteo Maiero)
-  * 4d88cd7bd4 - chore: Updated commons fileupload and commons io (#5902) (Pierantonio Merlino)
-  * d04ae54d64 - build: Update docker-java to 3.5.3 (#5881) [backport release-5.6.0]  (#5897) (Matteo Maiero)
-  * e2b1ea2344 - build: Upgraded netty to 4.1.121.Final [backport release-5.6.0] (#5823) (github-actions[bot])
-  * c3222c3fed - ci: fix Lint PR workflow permissions (#5824) (Mattia Dal Ben)
-  * cd0df913bd - chore: Update opcua dependency to align to Kura target platform [backport release-5.6.0] (#5805) (github-actions[bot])
-  * f8e420df15 - fix: Do not include router option if no nat [backport release-5.6.0] (#5753) (eclipse-kura-bot)
-  * 6588b69988 - build: Upgraded netty to 4.1.118.Final [backport release-5.6.0] (#5739) (eclipse-kura-bot)
-  * f3733694f5 - fix(distrib): kura_install.sh is broken [backport release-5.6.0] (#5647) (eclipse-kura-bot)
-  * bf26d47a2f - fix: release notes automation after Github executors update [backport release-5.6.0] (#5621) (eclipse-kura-bot)
-  * 3f00ed7e54 - feat: added MTU limits in webUI [backport release-5.6.0] (#5605) (eclipse-kura-bot)
-  * 3353d228cd - fix: Extended log download timeframe. Improved messages. [backport release-5.6.0] (#5600) (eclipse-kura-bot)
-  * 8633fc1e3b - fix(web2): Fixed wireless mode selection [backport release-5.6.0] (#5590) (eclipse-kura-bot)
-  * dd1fde9c0f - fix: correctly stopping gpsd thread [backport release-5.6.0] (#5588) (eclipse-kura-bot)
-  * a2a0047944 - fix: Fixed IPv6 validation [backport release-5.6.0] (#5582) (eclipse-kura-bot)
-  * 56e5f7a096 - fix: fixed loading of country code [backport release-5.6.0] (#5581) (eclipse-kura-bot)
-  * 025688e2e1 - fix: Improved ordering of services list [backport release-5.6.0] (#5577) (eclipse-kura-bot)
-  * eca56edecd - chore: automated uptick to 5.6.1-SNAPSHOT (#5575) (eclipse-kura-bot)
+  * 1ef6e8c141 - chore: automated uptick to 5.6.2 (#6232) (eclipse-kura-bot)
+  * 35c65ff6d9 - fix: Correctly handle X-Forwarded-For header for audit logging [backport release-5.6.0] (#6218) (Matteo Maiero)
+  * 745cd6df2d - chore: update netty to 4.1.132.Final [backport release-5.6.0] (#6216) (Matteo Maiero)
+  * d3a52a7c9a - chore: Updated Jetty to 9.4.58.v20250814 [backport release-5.6.0] (#6217) (Matteo Maiero)
+  * 1e53ce4c63 - ci: pin sonar-maven-plugin to 5.5.0.6356 and narrow binaries path (#6227) (Matteo Maiero)
+  * 56decab7f2 - ci: pin versions of Actions and Reusable Workflows [backport release-5.6.0] (#6212) (Mattia Dal Ben)
+  * f961ca425e - feat(linux.gpio.libgpiod): Added support to multiple pin listeners (#6197) (Pierantonio Merlino)
+  * a669473c20 - fix(linux.gpio.libgpiod): Fix GPIO events behavior in libgpiod v1 (#6184) (Pierantonio Merlino)
+  * f7456aca86 - fix: Fixed password encryption in ConfigurationService.createFactoryConfiguration [backport release-5.6.0] (#6182) (nicolatimeus)
+  * 255b68934d - fix: Fixed placeholder handling for password defaults [backport release-5.6.0] (#6189) (nicolatimeus)
+  * fcfc8699b6 - test: Improved CloudConnectionEndpointsTest [backport release-5.6.0] (#6186) (nicolatimeus)
+  * d9285a638a - ci: Specified sonar plugin version in JenkinsFile [backport release 5.6.0] (#6141) (Pierantonio Merlino)
+  * 26382c4b00 - chore: automated uptick to 5.6.2-SNAPSHOT (#6115) (eclipse-kura-bot)
+  * a1031da8c4 - ci(workflows): backport shared workflow to release 5.6.0 (#6117) (Mattia Dal Ben)


### PR DESCRIPTION
Automated changes by Release Notes automation action: add Kura 5.6.2 version release notes since commit `ed6e97d9b3cb118cddc7a046dc3b746585abd338`