### PR TITLE
ci(automation): avoid branch name collision on Release Notes workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -106,5 +106,5 @@ jobs:
         title: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
         commit-message: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
         body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.resolved-version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
-        branch-suffix: short-commit-hash
+        branch-suffix: timestamp
         token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Port of https://github.com/eclipse-kura/kura/pull/4945 to Release Notes automation