### PR TITLE
ci(automation): avoid branch name collision on Release Notes workflow [backport release-5.6.0]

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -107,5 +107,5 @@ jobs:
         title: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
         commit-message: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
         body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.resolved-version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
-        branch-suffix: short-commit-hash
+        branch-suffix: timestamp
         token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Backport of https://github.com/eclipse-kura/kura/pull/6236