### PR TITLE
fix(archetype): add support for REST/MQTT integration tests, readded missing about files

### DIFF
--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/.gitignore
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/.gitignore
@@ -14,3 +14,6 @@ OSGI-INF
 .flattened-pom.xml
 .tycho-consumer-pom.xml
 lib/
+generated/
+bin/
+.eclipse/

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/__package__/about.html
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/__package__/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/__package__/about_files/epl-v20.html
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/__package__/about_files/epl-v20.html
@@ -1,0 +1,301 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>Eclipse Public License - Version 2.0</title>
+  <style type="text/css">
+    body {
+      margin: 1.5em 3em;
+    }
+    h1{
+      font-size:1.5em;
+    }
+    h2{
+      font-size:1em;
+      margin-bottom:0.5em;
+      margin-top:1em;
+    }
+    p {
+      margin-top:  0.5em;
+      margin-bottom: 0.5em;
+    }
+    ul, ol{
+      list-style-type:none;
+    }
+  </style>
+</head>
+<body>
+<h1>Eclipse Public License - v 2.0</h1>
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+  PUBLIC LICENSE (&ldquo;AGREEMENT&rdquo;). ANY USE, REPRODUCTION OR DISTRIBUTION
+  OF THE PROGRAM CONSTITUTES RECIPIENT&#039;S ACCEPTANCE OF THIS AGREEMENT.
+</p>
+<h2 id="definitions">1. DEFINITIONS</h2>
+<p>&ldquo;Contribution&rdquo; means:</p>
+<ul>
+  <li>a) in the case of the initial Contributor, the initial content
+    Distributed under this Agreement, and
+  </li>
+  <li>
+    b) in the case of each subsequent Contributor:
+    <ul>
+      <li>i) changes to the Program, and</li>
+      <li>ii) additions to the Program;</li>
+    </ul>
+    where such changes and/or additions to the Program originate from
+    and are Distributed by that particular Contributor. A Contribution
+    &ldquo;originates&rdquo; from a Contributor if it was added to the Program by such
+    Contributor itself or anyone acting on such Contributor&#039;s behalf.
+    Contributions do not include changes or additions to the Program that
+    are not Modified Works.
+  </li>
+</ul>
+<p>&ldquo;Contributor&rdquo; means any person or entity that Distributes the Program.</p>
+<p>&ldquo;Licensed Patents&rdquo; mean patent claims licensable by a Contributor which
+  are necessarily infringed by the use or sale of its Contribution alone
+  or when combined with the Program.
+</p>
+<p>&ldquo;Program&rdquo; means the Contributions Distributed in accordance with this
+  Agreement.
+</p>
+<p>&ldquo;Recipient&rdquo; means anyone who receives the Program under this Agreement
+  or any Secondary License (as applicable), including Contributors.
+</p>
+<p>&ldquo;Derivative Works&rdquo; shall mean any work, whether in Source Code or other
+  form, that is based on (or derived from) the Program and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship.
+</p>
+<p>&ldquo;Modified Works&rdquo; shall mean any work in Source Code or other form that
+  results from an addition to, deletion from, or modification of the
+  contents of the Program, including, for purposes of clarity any new file
+  in Source Code form that contains any contents of the Program. Modified
+  Works shall not include works that contain only declarations, interfaces,
+  types, classes, structures, or files of the Program solely in each case
+  in order to link to, bind by name, or subclass the Program or Modified
+  Works thereof.
+</p>
+<p>&ldquo;Distribute&rdquo; means the acts of a) distributing or b) making available
+  in any manner that enables the transfer of a copy.
+</p>
+<p>&ldquo;Source Code&rdquo; means the form of a Program preferred for making
+  modifications, including but not limited to software source code,
+  documentation source, and configuration files.
+</p>
+<p>&ldquo;Secondary License&rdquo; means either the GNU General Public License,
+  Version 2.0, or any later versions of that license, including any
+  exceptions or additional permissions as identified by the initial
+  Contributor.
+</p>
+<h2 id="grant-of-rights">2. GRANT OF RIGHTS</h2>
+<ul>
+  <li>a) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free copyright
+    license to reproduce, prepare Derivative Works of, publicly display,
+    publicly perform, Distribute and sublicense the Contribution of such
+    Contributor, if any, and such Derivative Works.
+  </li>
+  <li>b) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free patent
+    license under Licensed Patents to make, use, sell, offer to sell,
+    import and otherwise transfer the Contribution of such Contributor,
+    if any, in Source Code or other form. This patent license shall
+    apply to the combination of the Contribution and the Program if,
+    at the time the Contribution is added by the Contributor, such
+    addition of the Contribution causes such combination to be covered
+    by the Licensed Patents. The patent license shall not apply to any
+    other combinations which include the Contribution. No hardware per
+    se is licensed hereunder.
+  </li>
+  <li>c) Recipient understands that although each Contributor grants the
+    licenses to its Contributions set forth herein, no assurances are
+    provided by any Contributor that the Program does not infringe the
+    patent or other intellectual property rights of any other entity.
+    Each Contributor disclaims any liability to Recipient for claims
+    brought by any other entity based on infringement of intellectual
+    property rights or otherwise. As a condition to exercising the rights
+    and licenses granted hereunder, each Recipient hereby assumes sole
+    responsibility to secure any other intellectual property rights needed,
+    if any. For example, if a third party patent license is required to
+    allow Recipient to Distribute the Program, it is Recipient&#039;s
+    responsibility to acquire that license before distributing the Program.
+  </li>
+  <li>d) Each Contributor represents that to its knowledge it has sufficient
+    copyright rights in its Contribution, if any, to grant the copyright
+    license set forth in this Agreement.
+  </li>
+  <li>e) Notwithstanding the terms of any Secondary License, no Contributor
+    makes additional grants to any Recipient (other than those set forth
+    in this Agreement) as a result of such Recipient&#039;s receipt of the
+    Program under the terms of a Secondary License (if permitted under
+    the terms of Section 3).
+  </li>
+</ul>
+<h2 id="requirements">3. REQUIREMENTS</h2>
+<p>3.1 If a Contributor Distributes the Program in any form, then:</p>
+<ul>
+  <li>a) the Program must also be made available as Source Code, in
+    accordance with section 3.2, and the Contributor must accompany
+    the Program with a statement that the Source Code for the Program
+    is available under this Agreement, and informs Recipients how to
+    obtain it in a reasonable manner on or through a medium customarily
+    used for software exchange; and
+  </li>
+  <li>
+    b) the Contributor may Distribute the Program under a license
+    different than this Agreement, provided that such license:
+    <ul>
+      <li>i) effectively disclaims on behalf of all other Contributors all
+        warranties and conditions, express and implied, including warranties
+        or conditions of title and non-infringement, and implied warranties
+        or conditions of merchantability and fitness for a particular purpose;
+      </li>
+      <li>ii) effectively excludes on behalf of all other Contributors all
+        liability for damages, including direct, indirect, special, incidental
+        and consequential damages, such as lost profits;
+      </li>
+      <li>iii) does not attempt to limit or alter the recipients&#039; rights in the
+        Source Code under section 3.2; and
+      </li>
+      <li>iv) requires any subsequent distribution of the Program by any party
+        to be under a license that satisfies the requirements of this section 3.
+      </li>
+    </ul>
+  </li>
+</ul>
+<p>3.2 When the Program is Distributed as Source Code:</p>
+<ul>
+  <li>a) it must be made available under this Agreement, or if the Program (i)
+    is combined with other material in a separate file or files made available
+    under a Secondary License, and (ii) the initial Contributor attached to
+    the Source Code the notice described in Exhibit A of this Agreement,
+    then the Program may be made available under the terms of such
+    Secondary Licenses, and
+  </li>
+  <li>b) a copy of this Agreement must be included with each copy of the Program.</li>
+</ul>
+<p>3.3 Contributors may not remove or alter any copyright, patent, trademark,
+  attribution notices, disclaimers of warranty, or limitations of liability
+  (&lsquo;notices&rsquo;) contained within the Program from any copy of the Program which
+  they Distribute, provided that Contributors may add their own appropriate
+  notices.
+</p>
+<h2 id="commercial-distribution">4. COMMERCIAL DISTRIBUTION</h2>
+<p>Commercial distributors of software may accept certain responsibilities
+  with respect to end users, business partners and the like. While this
+  license is intended to facilitate the commercial use of the Program, the
+  Contributor who includes the Program in a commercial product offering should
+  do so in a manner which does not create potential liability for other
+  Contributors. Therefore, if a Contributor includes the Program in a
+  commercial product offering, such Contributor (&ldquo;Commercial Contributor&rdquo;)
+  hereby agrees to defend and indemnify every other Contributor
+  (&ldquo;Indemnified Contributor&rdquo;) against any losses, damages and costs
+  (collectively &ldquo;Losses&rdquo;) arising from claims, lawsuits and other legal actions
+  brought by a third party against the Indemnified Contributor to the extent
+  caused by the acts or omissions of such Commercial Contributor in connection
+  with its distribution of the Program in a commercial product offering.
+  The obligations in this section do not apply to any claims or Losses relating
+  to any actual or alleged intellectual property infringement. In order to
+  qualify, an Indemnified Contributor must: a) promptly notify the
+  Commercial Contributor in writing of such claim, and b) allow the Commercial
+  Contributor to control, and cooperate with the Commercial Contributor in,
+  the defense and any related settlement negotiations. The Indemnified
+  Contributor may participate in any such claim at its own expense.
+</p>
+<p>For example, a Contributor might include the Program
+  in a commercial product offering, Product X. That Contributor is then a
+  Commercial Contributor. If that Commercial Contributor then makes performance
+  claims, or offers warranties related to Product X, those performance claims
+  and warranties are such Commercial Contributor&#039;s responsibility alone.
+  Under this section, the Commercial Contributor would have to defend claims
+  against the other Contributors related to those performance claims and
+  warranties, and if a court requires any other Contributor to pay any damages
+  as a result, the Commercial Contributor must pay those damages.
+</p>
+<h2 id="warranty">5. NO WARRANTY</h2>
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED
+  BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN &ldquo;AS IS&rdquo; BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
+  WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
+  MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is
+  solely responsible for determining the appropriateness of using and
+  distributing the Program and assumes all risks associated with its
+  exercise of rights under this Agreement, including but not limited to the
+  risks and costs of program errors, compliance with applicable laws, damage
+  to or loss of data, programs or equipment, and unavailability or
+  interruption of operations.
+</p>
+<h2 id="disclaimer">6. DISCLAIMER OF LIABILITY</h2>
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED
+  BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY
+  LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+  OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS),
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS
+  GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+</p>
+<h2 id="general">7. GENERAL</h2>
+<p>If any provision of this Agreement is invalid or unenforceable under
+  applicable law, it shall not affect the validity or enforceability of the
+  remainder of the terms of this Agreement, and without further action by the
+  parties hereto, such provision shall be reformed to the minimum extent
+  necessary to make such provision valid and enforceable.
+</p>
+<p>If Recipient institutes patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+  (excluding combinations of the Program with other software or hardware)
+  infringes such Recipient&#039;s patent(s), then such Recipient&#039;s rights granted
+  under Section 2(b) shall terminate as of the date such litigation is filed.
+</p>
+<p>All Recipient&#039;s rights under this Agreement shall terminate if it fails to
+  comply with any of the material terms or conditions of this Agreement and
+  does not cure such failure in a reasonable period of time after becoming
+  aware of such noncompliance. If all Recipient&#039;s rights under this Agreement
+  terminate, Recipient agrees to cease use and distribution of the Program
+  as soon as reasonably practicable. However, Recipient&#039;s obligations under
+  this Agreement and any licenses granted by Recipient relating to the
+  Program shall continue and survive.
+</p>
+<p>Everyone is permitted to copy and distribute copies of this Agreement,
+  but in order to avoid inconsistency the Agreement is copyrighted and may
+  only be modified in the following manner. The Agreement Steward reserves
+  the right to publish new versions (including revisions) of this Agreement
+  from time to time. No one other than the Agreement Steward has the right
+  to modify this Agreement. The Eclipse Foundation is the initial Agreement
+  Steward. The Eclipse Foundation may assign the responsibility to serve as
+  the Agreement Steward to a suitable separate entity. Each new version of
+  the Agreement will be given a distinguishing version number. The Program
+  (including Contributions) may always be Distributed subject to the version
+  of the Agreement under which it was received. In addition, after a new
+  version of the Agreement is published, Contributor may elect to Distribute
+  the Program (including its Contributions) under the new version.
+</p>
+<p>Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+  receives no rights or licenses to the intellectual property of any
+  Contributor under this Agreement, whether expressly, by implication,
+  estoppel or otherwise. All rights in the Program not expressly granted
+  under this Agreement are reserved. Nothing in this Agreement is intended
+  to be enforceable by any entity that is not a Contributor or Recipient.
+  No third-party beneficiary rights are created under this Agreement.
+</p>
+<h2 id="exhibit-a">Exhibit A &ndash; Form of Secondary Licenses Notice</h2>
+<p>&ldquo;This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set forth
+  in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+  version(s), and exceptions or additional permissions here}.&rdquo;
+</p>
+<blockquote>
+  <p>Simply including a copy of this Agreement, including this Exhibit A
+    is not sufficient to license the Source Code under Secondary Licenses.
+  </p>
+  <p>If it is not possible or desirable to put the notice in a particular file,
+    then You may include the notice in a location (such as a LICENSE file in a
+    relevant directory) where a recipient would be likely to look for
+    such a notice.
+  </p>
+  <p>You may add additional accurate notices of copyright ownership.</p>
+</blockquote>
+</body>
+</html>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/__package__/about_files/epl-v20.html
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/__package__/about_files/epl-v20.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/__package__/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/__package__/pom.xml
@@ -66,6 +66,8 @@
                     <bnd><![CDATA[
                         Bundle-SymbolicName: ${project.artifactId};singleton:=true
                         Bundle-ActivationPolicy: lazy
+                        -includeresource: about_files=about_files/,\
+                            about.html
                         ]]></bnd>
                 </configuration>
             </plugin>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/__package__.test/integration-test.bndrun
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/__package__.test/integration-test.bndrun
@@ -2,7 +2,7 @@ index: target/index.xml
 
 -standalone: ${index}
 
--resolve.effective: resolve
+-resolve.effective: active
 
 -runfw: org.eclipse.osgi
 
@@ -69,9 +69,8 @@ Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
 	osgi.identity;filter:='(osgi.identity=org.eclipse.kura.cloudconnection.kapua.mqtt.provider)',\
 	osgi.identity;filter:='(osgi.identity=org.eclipse.kura.db.h2db.provider)',\
 
-# Require tested and testing bundle
+# Require testing bundle
 -runrequires: \
-    osgi.identity;filter:='(osgi.identity=${replace;${project.artifactId};\\.test$;})',\
     osgi.identity;filter:='(osgi.identity=${project.artifactId})',\
 
 #

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/__package__.test/integration-test.bndrun
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/__package__.test/integration-test.bndrun
@@ -2,7 +2,7 @@ index: target/index.xml
 
 -standalone: ${index}
 
--resolve.effective: active
+-resolve.effective: resolve
 
 -runfw: org.eclipse.osgi
 
@@ -20,7 +20,8 @@ Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
     dpa.configuration=${kura.workdir}/data/dpa.properties,\
     kura.data=${kura.workdir}/data,\
     kura.snapshots=${kura.workdir}/user/snapshots,\
-    log4j.configurationFile=file:${kura.workdir}/log4j/log4j.xml
+    log4j.configurationFile=file:${kura.workdir}/log4j/log4j.xml,\
+    org.osgi.framework.bootdelegation='org.mockito.internal.creation.bytebuddy.inject'
 
 # Inject JaCoCo agent args produced by maven (prepare-agent)
 -runvm: \
@@ -53,19 +54,24 @@ Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator)',\
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator.clock)',\
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator.gpio)',\
-    osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator.gpio)',\
-    osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator.net)',\
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator.net)',\
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator.position)',\
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator.usb)',\
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.emulator.watchdog)',\
+    osgi.identity;filter:='(osgi.identity=org.eclipse.kura.http.server.manager)',\
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.json.marshaller.unmarshaller.provider)',\
-    osgi.identity;filter:='(osgi.identity=org.eclipse.kura.rest.provider)',\
-    osgi.identity;filter:='(osgi.identity=org.eclipse.kura.useradmin.store)',\
     osgi.identity;filter:='(osgi.identity=org.eclipse.kura.xml.marshaller.unmarshaller.provider)',\
+    osgi.identity;filter:='(osgi.identity=org.eclipse.kura.rest.provider)',\
+	osgi.identity;filter:='(osgi.identity=org.eclipse.kura.rest.security.provider)',\
+    osgi.identity;filter:='(osgi.identity=org.eclipse.kura.useradmin.store)',\
+    osgi.identity;filter:='(osgi.identity=org.eclipse.kura.cloud.base.provider)',\
+	osgi.identity;filter:='(osgi.identity=org.eclipse.kura.core.cloud.factory)',\
+	osgi.identity;filter:='(osgi.identity=org.eclipse.kura.cloudconnection.kapua.mqtt.provider)',\
+	osgi.identity;filter:='(osgi.identity=org.eclipse.kura.db.h2db.provider)',\
 
-# Require Testing bundle
+# Require tested and testing bundle
 -runrequires: \
+    osgi.identity;filter:='(osgi.identity=${replace;${project.artifactId};\\.test$;})',\
     osgi.identity;filter:='(osgi.identity=${project.artifactId})',\
 
 #

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/user/snapshots/snapshot_0.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/user/snapshots/snapshot_0.xml
@@ -170,7 +170,7 @@
     <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
         <esf:properties>
             <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
-                <esf:value>false</esf:value>
+                <esf:value>true</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled"
                 type="Boolean">

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/user/snapshots/snapshot_0.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/user/snapshots/snapshot_0.xml
@@ -206,4 +206,61 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.identity.PasswordStrengthVerificationService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="new.password.require.digits" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="new.password.require.special.characters" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="new.password.min.length" type="Integer">
+                <esf:value>1</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="new.password.require.both.cases" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.identity.PasswordStrengthVerificationService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.identity.PasswordStrengthVerificationService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.identity.LoginBannerService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="post.login.banner.content" type="String">
+                <esf:value>Sample Banner Content</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="post.login.banner.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="pre.login.banner.content" type="String">
+                <esf:value></esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="pre.login.banner.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.identity.LoginBannerService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.identity.LoginBannerService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.watchdog.WatchdogService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="pingInterval" type="Integer">
+                <esf:value>10000</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.watchdog.WatchdogService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>


### PR DESCRIPTION
This PR introduces some minor fixes to the Kura archetype. In particular:

- adds support for REST/MQTT endpoint integration tests by enabling some required configurations in the snapshot 0 and by adding missing requirements to the bndrun file
- adds `about.html` and `about_files` to the main bundle, and includes those files in the resulting JAR
- updates gitignore

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
