### PR TITLE
fix: misalignment between metatype and code in eclipseiot.mqtt bundle

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.CloudPublisher.xml
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.CloudPublisher.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2026 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,6 @@
             <Option label="Telemetry QoS 1" value="telemetryQos1" />
             <Option label="Event" value="event" />
             <Option label="Alert" value="alert" />
-            <Option label="Control" value="control" />
         </AD>
     </OCD>
     

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.CloudPublisher.xml
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.CloudPublisher.xml
@@ -2,16 +2,15 @@
 <!--
 
     Copyright (c) 2018, 2026 Eurotech and/or its affiliates and others
-  
+
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
- 
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
 
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kura.cloudconnection.eclipseiot.mqtt.CloudPublisher" 

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.CloudPublisher.xml
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.CloudPublisher.xml
@@ -36,8 +36,9 @@
             description="Type of message to be published.">
             <Option label="Telemetry QoS 0" value="telemetryQos0" />
             <Option label="Telemetry QoS 1" value="telemetryQos1" />
-            <Option label="Event" value="events" />
-            <Option label="Alert" value="alerts" />
+            <Option label="Event" value="event" />
+            <Option label="Alert" value="alert" />
+            <Option label="Control" value="control" />
         </AD>
     </OCD>
     


### PR DESCRIPTION
File:
`OSGI-INF/metatype/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.CloudPublisher.xml`

Current (broken):
`<Option label="Event" value="events" />`
`<Option label="Alert" value="alerts" />`

The MessageType enum uses singular strings as keys:
`EVENT("event", ...),`
`ALERT("alert", ...)`

`MessageType.fromValue()` iterates the enum and matches against the "type" field. Passing "alerts" or "events" (as stored by the Web Console after selecting those options) results in IllegalArgumentException at runtime. The component fails to activate and no message is ever published.

Fix:
`<Option label="Event" value="event" />`
`<Option label="Alert" value="alert" />`

--------------

Moreover, missing `control` was added.