### PR TITLE
fix(core.keystore): Fixed the addition of EC keypair

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core.keystore/META-INF/MANIFEST.MF
@@ -6,11 +6,14 @@ Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=21))"
 Import-Package: com.eclipsesource.json;version="0.9.5",
+ javax.net.ssl,
+ javax.security.auth.x500,
  org.bouncycastle.asn1;version="1.78.1",
  org.bouncycastle.asn1.cms;version="1.78.1",
  org.bouncycastle.asn1.pkcs;version="1.78.1",
  org.bouncycastle.asn1.x500;version="1.78.1",
  org.bouncycastle.asn1.x509;version="1.78.1",
+ org.bouncycastle.asn1.x9;version="1.78.1",
  org.bouncycastle.cert;version="1.78.1",
  org.bouncycastle.cert.jcajce;version="1.78.1",
  org.bouncycastle.cms;version="1.78.1",
@@ -40,9 +43,7 @@ Import-Package: com.eclipsesource.json;version="0.9.5",
  org.osgi.service.event;version="1.4.0",
  org.osgi.service.useradmin;version="1.1.0",
  org.osgi.util.tracker;version="1.5.2",
- org.slf4j;version="1.7.32",
- javax.net.ssl,
- javax.security.auth.x500
+ org.slf4j;version="1.7.32"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.kura.core.keystore.util;version="1.1.0"

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CertificateUtil.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CertificateUtil.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaCertStore;
@@ -137,7 +138,8 @@ public class CertificateUtil {
         try (Reader r = new StringReader(pemString); PEMParser pemParser = new PEMParser(r);) {
 
             PrivateKeyInfo privateKeyInfo;
-            JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC")
+                    .setAlgorithmMapping(X9ObjectIdentifiers.id_ecPublicKey, "EC");
 
             Object o = pemParser.readObject();
 

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CertificateUtil.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CertificateUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/KeystoreUtils.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/KeystoreUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2024, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/KeystoreUtils.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/KeystoreUtils.java
@@ -29,6 +29,7 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -36,21 +37,18 @@ import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 public class KeystoreUtils {
 
     private KeystoreUtils() {
-        // Empty constructor
     }
 
     public static PrivateKeyEntry createPrivateKey(String privateKey, String publicKey)
             throws IOException, GeneralSecurityException {
-        // Works with RSA and DSA. EC is not supported since the certificate is encoded
-        // with ECDSA while the corresponding private key with EC.
-        // This cause an error when the PrivateKeyEntry is generated.
-        Certificate[] certs = parsePublicCertificates(publicKey);
 
+        Certificate[] certs = parsePublicCertificates(publicKey);
         Security.addProvider(new BouncyCastleProvider());
         PEMParser pemParser = new PEMParser(new StringReader(privateKey));
         Object object = pemParser.readObject();
         pemParser.close();
-        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC")
+                .setAlgorithmMapping(X9ObjectIdentifiers.id_ecPublicKey, "EC");
         PrivateKey privkey = null;
         if (object instanceof org.bouncycastle.asn1.pkcs.PrivateKeyInfo) {
             privkey = converter.getPrivateKey((org.bouncycastle.asn1.pkcs.PrivateKeyInfo) object);

--- a/kura/test/org.eclipse.kura.core.keystore.test/build.properties
+++ b/kura/test/org.eclipse.kura.core.keystore.test/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2026 Eurotech and/or its affiliates and others
 # 
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,8 @@
 bin.includes = .,\
                META-INF/,\
                about.html
-source.. = src/main/java/
+source.. = src/test/java/,\
+           src/test/resources/
 additional.bundles = org.eclipse.kura.api,\
                      slf4j.api,\
                      org.apache.logging.log4j.api

--- a/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/util/KeystoreUtilsTest.java
+++ b/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/util/KeystoreUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -105,16 +105,19 @@ public class KeystoreUtilsTest {
             + "o135W+7AWr+dYRLx1FcvgMU9SbF9cwUU5Zutbrv+Kl8xGPyfx09MJ6BNxTkkr09J\n"
             + "BpbrbOZsUDjMjojyQYL4Ll9rLohk+Pq73xXJjtTRIXZVXJg27pEEqzcVB4o9vgli\n" + "yzOqhyTKM9JP7Uda6Fv6DA==\n"
             + "-----END PRIVATE KEY-----";
+    private static String privateKeyEC = "-----BEGIN EC PRIVATE KEY-----\n"
+            + "MHcCAQEEINPxE19vkUFNwfy99v6DSZcMSTRUAHYQhZ3CsUZadQ1woAoGCCqGSM49\n"
+            + "AwEHoUQDQgAESOVg3CaDAgtXzhrv0whx8aLFcDzbz7Cuhug+FER8JAwYBjWgW1TW\n"
+            + "TmYxwyPOgzIFMW31dqgIWl/EeE2qYvKQTA==\n" + "-----END EC PRIVATE KEY-----";
     private static String publicKeyEC = "-----BEGIN CERTIFICATE-----\n"
-            + "MIIBqjCCAU2gAwIBAgIELVNe7DAMBggqhkjOPQQDAgUAMEkxCzAJBgNVBAYTAnRy\n"
-            + "MQowCAYDVQQIEwE1MQowCAYDVQQHEwE0MQowCAYDVQQKEwEzMQowCAYDVQQLEwEy\n"
-            + "MQowCAYDVQQDEwExMB4XDTIxMDQxOTE1MDM0M1oXDTIxMDcxODE1MDM0M1owSTEL\n"
-            + "MAkGA1UEBhMCdHIxCjAIBgNVBAgTATUxCjAIBgNVBAcTATQxCjAIBgNVBAoTATMx\n"
-            + "CjAIBgNVBAsTATIxCjAIBgNVBAMTATEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC\n"
-            + "AARdxv7a46GcCcGrbbl9EolhfvKPJN4q8vfX8soAMFQ/7AOuKkz/2voFJ5kMK+gK\n"
-            + "31kbILrPnZa8IFmOB0d6qwLToyEwHzAdBgNVHQ4EFgQU0K3b/8VqxtBxW2dD81CB\n"
-            + "x9PyGUcwDAYIKoZIzj0EAwIFAANJADBGAiEAwN0V4/m/MAtEModdE27xB2bMC13i\n"
-            + "7KN7y088ENIykpICIQCjE9XItmBa405Bki9xe+n7T0eFhoCzAPk6lceZLzeFTQ==\n" + "-----END CERTIFICATE-----";
+            + "MIIBUjCB+aADAgECAhR2D5UAzcbk6uY/27htO/fqQCwXsDAKBggqhkjOPQQDAjAY\n"
+            + "MRYwFAYDVQQDDA1leGFtcGxlLmxvY2FsMB4XDTI2MDUyNzA5MjQyOFoXDTM2MDUy\n"
+            + "NDA5MjQyOFowGDEWMBQGA1UEAwwNZXhhbXBsZS5sb2NhbDBZMBMGByqGSM49AgEG\n"
+            + "CCqGSM49AwEHA0IABEjlYNwmgwILV84a79MIcfGixXA828+wroboPhREfCQMGAY1\n"
+            + "oFtU1k5mMcMjzoMyBTFt9XaoCFpfxHhNqmLykEyjITAfMB0GA1UdDgQWBBQ7+U8z\n"
+            + "ckKFekolxpHO4AilU6cihjAKBggqhkjOPQQDAgNIADBFAiEA1tDV9l7l/ese0a0x\n"
+            + "ZeOPu/IRArZpoPvqa0n8lgs//0ICIGXYJxv68y2zlgFyyqgFN6wevdxnfDGIhhap\n" + "kaJuLYnq\n"
+            + "-----END CERTIFICATE-----";
 
     @Test
     public void createCertificateDSAEntryTest() throws CertificateException {
@@ -148,6 +151,17 @@ public class KeystoreUtilsTest {
         assertEquals(256,
                 ((ECPublicKey) entry.getTrustedCertificate().getPublicKey()).getParams().getOrder().bitLength());
         assertEquals("X.509", entry.getTrustedCertificate().getType());
+
+    }
+
+    @Test
+    public void createPrivateKeyECEntryTest() throws IOException, GeneralSecurityException {
+        PrivateKeyEntry entry = KeystoreUtils.createPrivateKey(privateKeyEC, publicKeyEC);
+
+        assertNotNull(entry);
+        assertEquals("EC", entry.getCertificate().getPublicKey().getAlgorithm());
+        assertEquals(256, ((ECPublicKey) entry.getCertificate().getPublicKey()).getParams().getOrder().bitLength());
+        assertEquals("X.509", entry.getCertificate().getType());
 
     }
 

--- a/kura/test/org.eclipse.kura.rest.keystore.provider.test/src/test/java/org/eclipse/kura/rest/keystore/provider/request/handler/KeystoreServiceRequestHandlerTest.java
+++ b/kura/test/org.eclipse.kura.rest.keystore.provider.test/src/test/java/org/eclipse/kura/rest/keystore/provider/request/handler/KeystoreServiceRequestHandlerTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import javax.security.auth.x500.X500Principal;
 
+import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -649,16 +650,13 @@ public class KeystoreServiceRequestHandlerTest {
 
     private PrivateKeyEntry createPrivateKey(String alias, String privateKey, String[] certificateChain)
             throws IOException, GeneralSecurityException, KuraException {
-        // Works with RSA and DSA. EC is not supported since the certificate is encoded
-        // with ECDSA while the corresponding private key with EC.
-        // This cause an error when the PrivateKeyEntry is generated.
         Certificate[] certs = parsePublicCertificates(certificateChain);
 
         Security.addProvider(new BouncyCastleProvider());
         PEMParser pemParser = new PEMParser(new StringReader(privateKey));
         Object object = pemParser.readObject();
         pemParser.close();
-        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC").setAlgorithmMapping(X9ObjectIdentifiers.id_ecPublicKey, "EC");
         PrivateKey privkey = null;
         if (object instanceof org.bouncycastle.asn1.pkcs.PrivateKeyInfo) {
             privkey = converter.getPrivateKey((org.bouncycastle.asn1.pkcs.PrivateKeyInfo) object);


### PR DESCRIPTION
This pull request updates the keystore utility code to improve support for EC (Elliptic Curve) private keys by explicitly mapping the EC algorithm when converting keys with BouncyCastle. It also makes minor adjustments to the OSGi manifest to correctly manage package imports.

**Improvements to EC Private Key Handling:**
* Updated both `CertificateUtil.java` and `KeystoreUtils.java` to use `JcaPEMKeyConverter#setAlgorithmMapping` for mapping `X9ObjectIdentifiers.id_ecPublicKey` to "EC", ensuring proper conversion of EC private keys. [[1]](diffhunk://#diff-7ad0cd978e4f0683ae4727f05f7cef46fcac062cac426d3058a2a8574e296592R49) [[2]](diffhunk://#diff-7ad0cd978e4f0683ae4727f05f7cef46fcac062cac426d3058a2a8574e296592L140-R142) [[3]](diffhunk://#diff-7dfc8620cb1680a68a8a73dd7712af572c7c31107b8cf683238d8fb506167307R32-R51)

**Manifest and Dependency Management:**
* Adjusted `META-INF/MANIFEST.MF` to add and remove relevant package imports, specifically moving `javax.net.ssl` and `javax.security.auth.x500` to the correct section and adding `org.bouncycastle.asn1.x9`. [[1]](diffhunk://#diff-7c04bf5e3a270282eca03b4be62cfd2dfc06e869d629abe3fbab7ac3ccd31012R9-R16) [[2]](diffhunk://#diff-7c04bf5e3a270282eca03b4be62cfd2dfc06e869d629abe3fbab7ac3ccd31012L43-R46)