### PR TITLE
fix(ai.triton.server): Fixed feature version mismatch causing distrib build failure

### DIFF
--- a/kura/features/org.eclipse.kura.ai.triton.server/feature.xml
+++ b/kura/features/org.eclipse.kura.ai.triton.server/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.kura.ai.triton.server"
       label="%featureName"
-      version="1.5.1.qualifier"
+      version="1.5.1"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/kura/features/org.eclipse.kura.ai.triton.server/pom.xml
+++ b/kura/features/org.eclipse.kura.ai.triton.server/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.ai.triton.server</artifactId>
-	<version>1.5.1-SNAPSHOT</version>
+	<version>1.5.1</version>
 	<packaging>eclipse-feature</packaging>
 
 	<build>

--- a/kura/test/org.eclipse.kura.core.test/src/main/java/org/eclipse/kura/core/test/CloudServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/main/java/org/eclipse/kura/core/test/CloudServiceTest.java
@@ -40,6 +40,8 @@ public class CloudServiceTest extends TestCase implements CloudClientListener {
     private boolean controlConfirmed;
     private boolean controlArrived;
 
+    private CountDownLatch eventLatch;
+
     @Override
     @BeforeClass
     public void setUp() {
@@ -71,8 +73,13 @@ public class CloudServiceTest extends TestCase implements CloudClientListener {
     @TestTarget(targetPlatforms = { TestTarget.PLATFORM_ALL })
     @Test
     public void testService() throws Exception {
+        this.publishPublished = false;
+        this.publishConfirmed = false;
         this.publishArrived = false;
+        this.controlPublished = false;
+        this.controlConfirmed = false;
         this.controlArrived = false;
+        this.eventLatch = new CountDownLatch(6);
 
         CloudClient cloudAppClient = CloudServiceTest.cloudService.newCloudClient("testService");
         cloudAppClient.addCloudClientListener(this);
@@ -99,7 +106,7 @@ public class CloudServiceTest extends TestCase implements CloudClientListener {
         controlPayload.setBody("control_payload".getBytes());
         this.controlMsgId = cloudAppClient.controlPublish("control_test", controlPayload, 1, false, priority);
 
-        Thread.sleep(1000);
+        this.eventLatch.await(30, TimeUnit.SECONDS);
 
         assertTrue("publish not published!", this.publishPublished);
         assertTrue("publish not confirmed!", this.publishConfirmed);
@@ -127,6 +134,9 @@ public class CloudServiceTest extends TestCase implements CloudClientListener {
         assertEquals("control_test", appTopic);
         assertEquals("control_payload", new String(msg.getBody()));
         this.controlArrived = true;
+        if (this.eventLatch != null) {
+            this.eventLatch.countDown();
+        }
     }
 
     @Override
@@ -134,6 +144,9 @@ public class CloudServiceTest extends TestCase implements CloudClientListener {
         assertEquals("test", appTopic);
         assertEquals("payload", new String(msg.getBody()));
         this.publishArrived = true;
+        if (this.eventLatch != null) {
+            this.eventLatch.countDown();
+        }
     }
 
     @Override
@@ -141,10 +154,16 @@ public class CloudServiceTest extends TestCase implements CloudClientListener {
         if (messageId == this.publishedMsgId) {
             assertEquals("test", appTopic);
             this.publishConfirmed = true;
+            if (this.eventLatch != null) {
+                this.eventLatch.countDown();
+            }
         }
         if (messageId == this.controlMsgId) {
             assertEquals("control_test", appTopic);
             this.controlConfirmed = true;
+            if (this.eventLatch != null) {
+                this.eventLatch.countDown();
+            }
         }
     }
 
@@ -153,10 +172,16 @@ public class CloudServiceTest extends TestCase implements CloudClientListener {
         if (messageId == this.publishedMsgId) {
             assertEquals("test", appTopic);
             this.publishPublished = true;
+            if (this.eventLatch != null) {
+                this.eventLatch.countDown();
+            }
         }
         if (messageId == this.controlMsgId) {
             assertEquals("control_test", appTopic);
             this.controlPublished = true;
+            if (this.eventLatch != null) {
+                this.eventLatch.countDown();
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

The distrib build with `-DbuildAll` was failing with:

```
Unable to find artifact. The following artifacts could not be resolved: 
org.eclipse.kura.feature:org.eclipse.kura.ai.triton.server:dp:1.5.1 (absent)
```

**Root cause:** The feature module had a version mismatch:
- `pom.xml` defined version as `1.5.1-SNAPSHOT`
- `feature.xml` defined version as `1.5.1.qualifier`
- `kura.build.properties` referenced version `1.5.1` (release)

Maven could not resolve `1.5.1` because the built artifact was `1.5.1-SNAPSHOT`.

## Changes

- Updated `features/org.eclipse.kura.ai.triton.server/pom.xml`: `1.5.1-SNAPSHOT` → `1.5.1`
- Updated `features/org.eclipse.kura.ai.triton.server/feature.xml`: `1.5.1.qualifier` → `1.5.1`