### PR TITLE
fix(cloud.base.provider): clear non-empty default for MqttDataTransport password

### DIFF
--- a/kura/org.eclipse.kura.cloud.base.provider/OSGI-INF/metatype/org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml
+++ b/kura/org.eclipse.kura.cloud.base.provider/OSGI-INF/metatype/org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -45,12 +45,12 @@
             default="username" 
             description="Username to be used when connecting to the MQTT broker."/>
 
-        <AD id="password"  
+        <AD id="password"
             name="Password"
             type="Password"
-            cardinality="0" 
+            cardinality="0"
             required="false"
-            default="password" 
+            default=""
             description="Password to be used when connecting to the MQTT broker."/>
 
         <AD id="client-id"

--- a/kura/org.eclipse.kura.cloud.base.provider/OSGI-INF/metatype/org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml
+++ b/kura/org.eclipse.kura.cloud.base.provider/OSGI-INF/metatype/org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml
@@ -2,15 +2,15 @@
 <!--
 
     Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
-  
+
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
- 
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
      Benjamin Cabé <benjamin@eclipse.org>
 
 -->


### PR DESCRIPTION
## Summary

Port of [eclipse-kura/kura#6257](https://github.com/eclipse-kura/kura/pull/6257) (metatype part) to the Kura 6 split-repo layout.

- `org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml`: change `default="password"` to `default=""` on the `password` AD element so `mergeWithDefaults()` does not inject a non-empty password for components that have never had one configured

## Root cause

For any `MqttDataTransport` component instance where the `password` key was never explicitly written to ConfigAdmin, `mergeWithDefaults()` would inject `Password("password")` as the credential. On the next broker connect attempt the framework decrypted this value and sent `"password"` as the MQTT password, causing authentication failure against brokers that require no password or a different one.

## Test plan

- [ ] Verify broker connection succeeds with empty password after device reboot / first-time component creation
- [ ] Verify broker connection still succeeds when a real password is explicitly configured