### PR TITLE
fix: Added missing crypto secret key property

### DIFF
--- a/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura.sh
+++ b/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura.sh
@@ -90,6 +90,7 @@ KURA_CMD="${KURA_LAUNCH_COMMAND} -Xms${kura.mem.size} -Xmx${kura.mem.size} \
     -Dkura.os.version=${kura.os.version} \
     -Dkura.arch=${kura.arch} \
     -Dtarget.device=${target.device} \
+    -Dorg.eclipse.kura.core.crypto.secretKey="$KURA_CRYPTO_SECRET_KEY" \
     -Declipse.ignoreApp=true \
     -Dkura.home=\${DIR} \
     -Dkura.configuration=file:\${DIR}/framework/kura.properties \


### PR DESCRIPTION
This PR adds the missing `KURA_CRYPTO_SECRET_KEY` property in the Kura startup script.