### PR TITLE
fix(distrib): wrong version number for installed BC artifacts

### DIFF
--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -93,7 +93,7 @@ jaxb-osgi.version=2.3.3
 osgi-resource-locator.version=1.0.3
 
 org.bouncycastle.version=1.84
-org.bouncycastle.jar.version=1.84
+org.bouncycastle.jar.version=1.84.0
 
 com.eurotech.gpsd4java.version=1.0.0
 libsocket-can-osgi.version=1.4.0


### PR DESCRIPTION
The BouncyCastle JARs names present at installation in `/opt/eclipse/kura/plugins` are different from those in the `config.ini`, causing the framework to not start.

This is because the Tycho P2 extras plugin changes the published JAR names by appending an inferred patch version if that is missing (see https://tycho.eclipseprojects.io/doc/main/tycho-extras/tycho-p2-extras-plugin/publish-features-and-bundles-mojo.html and https://wiki.eclipse.org/Equinox/p2/Publisher#Features_And_Bundles_Publisher_Application).

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
