### PR TITLE
fix(test): fix intermittent failures in h2db provider tests due to shared state

### DIFF
--- a/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/DbDataStoreStorageTest.java
+++ b/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/DbDataStoreStorageTest.java
@@ -295,11 +295,6 @@ public class DbDataStoreStorageTest {
     @After
     public void tearDown() throws SQLException {
         if (this.keepAliveConnection != null && !this.keepAliveConnection.isClosed()) {
-            try (Statement st = this.keepAliveConnection.createStatement()) {
-                st.execute("SHUTDOWN");
-            } catch (SQLException ignored) {
-                // ignore shutdown errors
-            }
             this.keepAliveConnection.close();
         }
     }

--- a/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/DbDataStoreStorageTest.java
+++ b/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/DbDataStoreStorageTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2022, 2026 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  ******************************************************************************/
@@ -25,6 +25,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.UUID;
 
 import org.eclipse.kura.KuraStoreException;
 import org.eclipse.kura.db.H2DbService;
@@ -33,6 +34,7 @@ import org.eclipse.kura.message.store.StoredMessage;
 import org.eclipse.kura.message.store.provider.MessageStore;
 import org.eclipse.kura.util.jdbc.ConnectionProvider;
 import org.eclipse.kura.util.jdbc.SQLFunction;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,6 +54,8 @@ public class DbDataStoreStorageTest {
 
     private MessageStore dataStore;
     private int messageId;
+    private String dbName;
+    private Connection keepAliveConnection;
 
     /*
      * Scenarios
@@ -182,18 +186,17 @@ public class DbDataStoreStorageTest {
                 this.messageId = this.dataStore.store(TOPIC, this.payload, QOS2, true, PRIORITY_LOW);
 
                 Class.forName("org.h2.Driver");
-                Connection c = DriverManager.getConnection("jdbc:h2:mem:testdb;", "sa", "");
-
-                // keep just one message at every moment
-                for (int j = 0; j < i; j++) {
-                    PreparedStatement stmt = c.prepareStatement("DELETE FROM ? WHERE ID=?;");
-                    stmt.setString(1, TABLE_NAME);
-                    stmt.setInt(2, i);
-                    stmt.execute();
+                try (Connection c = DriverManager.getConnection(
+                        "jdbc:h2:mem:" + this.dbName + ";DB_CLOSE_DELAY=-1", "sa", "")) {
+                    // keep just one message at every moment
+                    for (int j = 0; j < i; j++) {
+                        PreparedStatement stmt = c.prepareStatement("DELETE FROM ? WHERE ID=?;");
+                        stmt.setString(1, TABLE_NAME);
+                        stmt.setInt(2, i);
+                        stmt.execute();
+                    }
+                    c.commit();
                 }
-
-                c.commit();
-
             }
 
             this.messageId = this.dataStore.store(TOPIC, this.payload, QOS2, true, PRIORITY_LOW);
@@ -230,36 +233,37 @@ public class DbDataStoreStorageTest {
 
         // also inspect the database
         try {
-
             Class.forName("org.h2.Driver");
-            Connection c = DriverManager.getConnection("jdbc:h2:mem:testdb;", "sa", "");
-            PreparedStatement stmt = c.prepareStatement("SELECT * FROM ?;", Statement.RETURN_GENERATED_KEYS);
-            stmt.setString(1, TABLE_NAME);
-            ResultSet rs = stmt.executeQuery();
+            try (Connection c = DriverManager.getConnection(
+                    "jdbc:h2:mem:" + this.dbName + ";DB_CLOSE_DELAY=-1", "sa", "");
+                    PreparedStatement stmt = c.prepareStatement("SELECT * FROM ?;",
+                            Statement.RETURN_GENERATED_KEYS)) {
+                stmt.setString(1, TABLE_NAME);
+                ResultSet rs = stmt.executeQuery();
 
-            while (rs.next()) {
-                if (rs.getInt("id") == message.getId()) {
-                    String rowTopic = rs.getString("topic");
-                    int rowQos = rs.getInt("qos");
-                    boolean rowRetain = rs.getBoolean("retain");
-                    byte[] smallPayload = rs.getBytes("smallPayload");
-                    byte[] largePayload = rs.getBytes("largePayload");
-                    int rowPriority = rs.getInt("priority");
+                while (rs.next()) {
+                    if (rs.getInt("id") == message.getId()) {
+                        String rowTopic = rs.getString("topic");
+                        int rowQos = rs.getInt("qos");
+                        boolean rowRetain = rs.getBoolean("retain");
+                        byte[] smallPayload = rs.getBytes("smallPayload");
+                        byte[] largePayload = rs.getBytes("largePayload");
+                        int rowPriority = rs.getInt("priority");
 
-                    assertEquals(topic, rowTopic);
-                    assertEquals(qos, rowQos);
-                    assertEquals(retain, rowRetain);
-                    assertEquals(priority, rowPriority);
-                    if (message.getPayload().length < 200) {
-                        assertTrue(Arrays.equals(payload, smallPayload));
-                        assertNull(largePayload);
-                    } else {
-                        assertTrue(Arrays.equals(payload, largePayload));
-                        assertNull(smallPayload);
+                        assertEquals(topic, rowTopic);
+                        assertEquals(qos, rowQos);
+                        assertEquals(retain, rowRetain);
+                        assertEquals(priority, rowPriority);
+                        if (message.getPayload().length < 200) {
+                            assertTrue(Arrays.equals(payload, smallPayload));
+                            assertNull(largePayload);
+                        } else {
+                            assertTrue(Arrays.equals(payload, largePayload));
+                            assertNull(smallPayload);
+                        }
                     }
                 }
             }
-
         } catch (SQLException | ClassNotFoundException e) {
             this.occurredException = e;
         }
@@ -279,8 +283,25 @@ public class DbDataStoreStorageTest {
      */
 
     @Before
-    public void cleanUp() {
+    public void setUp() throws SQLException, ClassNotFoundException {
         this.occurredException = null;
+        this.dbName = "testdb_" + UUID.randomUUID().toString().replace("-", "");
+        // Hold a connection open to prevent H2 from dropping the in-memory DB between steps
+        Class.forName("org.h2.Driver");
+        this.keepAliveConnection = DriverManager.getConnection("jdbc:h2:mem:" + this.dbName + ";DB_CLOSE_DELAY=-1",
+                "sa", "");
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        if (this.keepAliveConnection != null && !this.keepAliveConnection.isClosed()) {
+            try (Statement st = this.keepAliveConnection.createStatement()) {
+                st.execute("SHUTDOWN");
+            } catch (SQLException ignored) {
+                // ignore shutdown errors
+            }
+            this.keepAliveConnection.close();
+        }
     }
 
     private final class MockH2DbService implements H2DbService {
@@ -289,7 +310,8 @@ public class DbDataStoreStorageTest {
         public Connection getConnection() throws SQLException {
             try {
                 Class.forName("org.h2.Driver");
-                return DriverManager.getConnection("jdbc:h2:mem:testdb;", "sa", "");
+                return DriverManager.getConnection(
+                        "jdbc:h2:mem:" + DbDataStoreStorageTest.this.dbName + ";DB_CLOSE_DELAY=-1", "sa", "");
             } catch (ClassNotFoundException e) {
                 DbDataStoreStorageTest.this.occurredException = e;
             }

--- a/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/H2DbServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/H2DbServiceImplTest.java
@@ -49,7 +49,6 @@ public class H2DbServiceImplTest {
         H2DbServiceImpl svc = new H2DbServiceImpl();
         CryptoService csMock = mock(CryptoService.class);
         when(csMock.decryptAes(any(char[].class))).thenReturn(new char[0]);
-        when(csMock.decryptAes(encPass)).thenReturn(pass.toCharArray());
         svc.setCryptoService(csMock);
         svc.activate(Collections.emptyMap());
 

--- a/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/H2DbServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/H2DbServiceImplTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2017, 2026 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  ******************************************************************************/
@@ -15,6 +15,7 @@ package org.eclipse.kura.internal.db.h2db.provider;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,12 +47,11 @@ public class H2DbServiceImplTest {
         String user = "USR";
 
         H2DbServiceImpl svc = new H2DbServiceImpl();
-        svc.activate(Collections.emptyMap());
-
         CryptoService csMock = mock(CryptoService.class);
-        svc.setCryptoService(csMock);
-
+        when(csMock.decryptAes(any(char[].class))).thenReturn(new char[0]);
         when(csMock.decryptAes(encPass)).thenReturn(pass.toCharArray());
+        svc.setCryptoService(csMock);
+        svc.activate(Collections.emptyMap());
 
         Map<String, Object> props = new HashMap<>();
         props.put("db.user", user);
@@ -85,24 +85,31 @@ public class H2DbServiceImplTest {
         String user = "USR";
 
         H2DbServiceImpl svc = new H2DbServiceImpl();
+        CryptoService csMock = mock(CryptoService.class);
+        when(csMock.decryptAes(any(char[].class))).thenReturn(new char[0]);
+        svc.setCryptoService(csMock);
         svc.activate(Collections.emptyMap());
 
-        Map<String, Object> props = new HashMap<>();
-        props.put("db.user", user);
-        props.put("db.password", pass);
-        props.put("db.connection.pool.max.size", 10);
-        props.put("db.connector.url", "jdb:h2:mem:testdb");
-
         try {
-            svc.getConnection();
-        } catch (SQLException e) {
-            assertTrue(e.getMessage().contains("not initialized"));
-        }
+            Map<String, Object> props = new HashMap<>();
+            props.put("db.user", user);
+            props.put("db.password", pass);
+            props.put("db.connection.pool.max.size", 10);
+            props.put("db.connector.url", "jdb:h2:mem:testdb");
 
-        try {
-            svc.updated(props);
-        } catch (IllegalArgumentException e) {
-            assertEquals("Invalid DB URL", e.getMessage());
+            try {
+                svc.getConnection();
+            } catch (SQLException e) {
+                assertTrue(e.getMessage().contains("not initialized"));
+            }
+
+            try {
+                svc.updated(props);
+            } catch (IllegalArgumentException e) {
+                assertEquals("Invalid DB URL", e.getMessage());
+            }
+        } finally {
+            svc.deactivate();
         }
     }
 
@@ -112,78 +119,93 @@ public class H2DbServiceImplTest {
         String user = "USR";
 
         H2DbServiceImpl svc = new H2DbServiceImpl();
+        CryptoService csMock = mock(CryptoService.class);
+        when(csMock.decryptAes(any(char[].class))).thenReturn(new char[0]);
+        svc.setCryptoService(csMock);
         svc.activate(Collections.emptyMap());
 
-        Map<String, Object> props = new HashMap<>();
-        props.put("db.user", user);
-        props.put("db.password", pass);
-        props.put("db.connection.pool.max.size", 10);
-        props.put("db.connector.url", "jdbc:h3:mem:testdb");
-
         try {
-            svc.getConnection();
-        } catch (SQLException e) {
-            assertTrue(e.getMessage().contains("not initialized"));
-        }
+            Map<String, Object> props = new HashMap<>();
+            props.put("db.user", user);
+            props.put("db.password", pass);
+            props.put("db.connection.pool.max.size", 10);
+            props.put("db.connector.url", "jdbc:h3:mem:testdb");
 
-        try {
-            svc.updated(props);
-        } catch (IllegalArgumentException e) {
-            assertEquals("JDBC driver must be h2", e.getMessage());
+            try {
+                svc.getConnection();
+            } catch (SQLException e) {
+                assertTrue(e.getMessage().contains("not initialized"));
+            }
+
+            try {
+                svc.updated(props);
+            } catch (IllegalArgumentException e) {
+                assertEquals("JDBC driver must be h2", e.getMessage());
+            }
+        } finally {
+            svc.deactivate();
         }
     }
 
     @Test
     public void testUpdateFailRemote() throws Throwable {
         final String enc = "enc";
-        char[] encPass = enc.toCharArray();
-        String pass = "pass";
         String user = "USR";
 
         H2DbServiceImpl svc = new H2DbServiceImpl();
+        CryptoService csMock = mock(CryptoService.class);
+        when(csMock.decryptAes(any(char[].class))).thenReturn(new char[0]);
+        svc.setCryptoService(csMock);
         svc.activate(Collections.emptyMap());
 
-        Map<String, Object> props = new HashMap<>();
-        props.put("db.user", user);
-        props.put("db.password", enc);
-        props.put("db.connection.pool.max.size", 10);
-        props.put("db.connector.url", "jdbc:h2:rmt:test");
-
         try {
-            svc.updated(props);
-        } catch (IllegalArgumentException e) {
-            assertEquals("Remote databases are not supported", e.getMessage());
+            Map<String, Object> props = new HashMap<>();
+            props.put("db.user", user);
+            props.put("db.password", enc);
+            props.put("db.connection.pool.max.size", 10);
+            props.put("db.connector.url", "jdbc:h2:rmt:test");
+
+            try {
+                svc.updated(props);
+            } catch (IllegalArgumentException e) {
+                assertEquals("Remote databases are not supported", e.getMessage());
+            }
+        } finally {
+            svc.deactivate();
         }
     }
 
     @Test
     public void testUpdateFailAnonymous() throws Throwable {
         final String enc = "enc";
-        char[] encPass = enc.toCharArray();
-        String pass = "pass";
         String user = "USR";
 
         H2DbServiceImpl svc = new H2DbServiceImpl();
+        CryptoService csMock = mock(CryptoService.class);
+        when(csMock.decryptAes(any(char[].class))).thenReturn(new char[0]);
+        svc.setCryptoService(csMock);
         svc.activate(Collections.emptyMap());
 
-        Map<String, Object> props = new HashMap<>();
-        props.put("db.user", user);
-        props.put("db.password", enc);
-        props.put("db.connection.pool.max.size", 10);
-        props.put("db.connector.url", "jdbc:h2:mem:");
-
         try {
-            svc.updated(props);
-        } catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().startsWith("Anonymous"));
+            Map<String, Object> props = new HashMap<>();
+            props.put("db.user", user);
+            props.put("db.password", enc);
+            props.put("db.connection.pool.max.size", 10);
+            props.put("db.connector.url", "jdbc:h2:mem:");
+
+            try {
+                svc.updated(props);
+            } catch (IllegalArgumentException e) {
+                assertTrue(e.getMessage().startsWith("Anonymous"));
+            }
+        } finally {
+            svc.deactivate();
         }
     }
 
     @Test
     public void testUpdateFailUrlOccupied() throws Throwable {
         final String enc = "enc";
-        char[] encPass = enc.toCharArray();
-        String pass = "pass";
         String user = "USR";
         String url = "jdbc:h2:mem:test";
 
@@ -193,18 +215,26 @@ public class H2DbServiceImplTest {
         activeInstances.put(url, svc1);
 
         H2DbServiceImpl svc = new H2DbServiceImpl();
-        svc.activate(Collections.emptyMap());
-
-        Map<String, Object> props = new HashMap<>();
-        props.put("db.user", user);
-        props.put("db.password", enc);
-        props.put("db.connection.pool.max.size", 10);
-        props.put("db.connector.url", url);
-
         try {
-            svc.updated(props);
-        } catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().startsWith("Another H2DbService instance"));
+            CryptoService csMock = mock(CryptoService.class);
+            when(csMock.decryptAes(any(char[].class))).thenReturn(new char[0]);
+            svc.setCryptoService(csMock);
+            svc.activate(Collections.emptyMap());
+
+            Map<String, Object> props = new HashMap<>();
+            props.put("db.user", user);
+            props.put("db.password", enc);
+            props.put("db.connection.pool.max.size", 10);
+            props.put("db.connector.url", url);
+
+            try {
+                svc.updated(props);
+            } catch (IllegalArgumentException e) {
+                assertTrue(e.getMessage().startsWith("Another H2DbService instance"));
+            }
+        } finally {
+            svc.deactivate();
+            activeInstances.remove(url);
         }
     }
 
@@ -217,12 +247,11 @@ public class H2DbServiceImplTest {
         String user = "USR";
 
         H2DbServiceImpl svc = new H2DbServiceImpl();
-        svc.activate(Collections.emptyMap());
-
         CryptoService csMock = mock(CryptoService.class);
-        svc.setCryptoService(csMock);
-
+        when(csMock.decryptAes(any(char[].class))).thenReturn(new char[0]);
         when(csMock.decryptAes(encPass)).thenReturn(pass.toCharArray());
+        svc.setCryptoService(csMock);
+        svc.activate(Collections.emptyMap());
 
         Map<String, Object> props = new HashMap<>();
         props.put("db.user", user);


### PR DESCRIPTION
## Summary

- **`DbDataStoreStorageTest`**: all tests were connecting to the same `jdbc:h2:mem:testdb` database, causing inter-test interference when run in any order. Each test now gets an isolated in-memory DB with a UUID-based name (`testdb_<uuid>`) and `DB_CLOSE_DELAY=-1`. A keep-alive connection is held open for the duration of the test via `@Before`/`@After`. JDBC connections opened inside `whenOverflowingIds` and `thenStoredMessageIs` are now properly closed via try-with-resources.
- **`H2DbServiceImplTest`**: `testUpdateUrlOccupied` was injecting an entry into the static `activeInstances` map without ever removing it, contaminating all subsequent tests. The entry is now removed in a `finally` block.

## Test plan

- [x] `mvn clean install` run 20 consecutive times on `org.eclipse.kura.db.h2db.provider.test` — all 20 passed (0 failures)

