### PR TITLE
docs: Update SECURITY.md following policy change

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,10 @@ The fixes are applied to the latest minor release available for the given major 
 
 ## Reporting a Vulnerability
 
-If you think you have found a vulnerability in Eclipse Kura you can report it using one of the following ways:
+If you think you have found a vulnerability in Eclipse Kura, please report it to us through coordinated disclosure.
 
-* [Report a Vulnerability](https://github.com/eclipse-kura/kura/security/advisories/new)
-* Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org)
+**Please do not report security vulnerabilities through public issues, discussions, or change requests.**
+
+Instead, report it creating a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
 
 You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).


### PR DESCRIPTION
Per Eclipse Foundation annoucement:

> We're writing to announce an update to how the Eclipse Foundation Security Team receives and handles vulnerability reports addressed to projects. Effective today, the team will no longer accept vulnerability reports submitted by email. 
> \[...\]
> Because the reporting channels have changed, your project's SECURITY.md may now point to options that are no longer valid. We've prepared an updated template reflecting these changes, which can be found here: https://github.com/eclipse-csi/security-handbook/blob/main/templates/SECURITY.md
>
>We kindly ask each project to update its SECURITY.md to list only supported channels.

Reference: https://github.com/orgs/eclipse-csi/discussions/16