### PR TITLE
build: added Netty native classes in distrib build

### DIFF
--- a/kura/distrib/aarch64-core/pom.xml
+++ b/kura/distrib/aarch64-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Eurotech and/or its affiliates and others
+    Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/aarch64-core/pom.xml
+++ b/kura/distrib/aarch64-core/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <kura.basedir>../</kura.basedir>
         <kura.arch>aarch64</kura.arch>
+        <alt.native.tag>aarch_64</alt.native.tag>
         <target.device>${kura.arch}</target.device>
         <arch>${kura.arch}</arch>
         <deb.name>kura-core</deb.name>

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -507,9 +507,7 @@
                                     <!-- netty-plugins --> 
                                     netty-common, netty-codec-http, netty-codec, netty-transport, netty-buffer,
                                     netty-transport-classes-epoll, netty-resolver, netty-handler,
-                                    netty-transport-classes-kqueue, netty-transport-native-epoll,
-                                    netty-codec-mqtt, netty-transport-native-kqueue,
-                                    netty-transport-native-unix-common,
+                                    netty-codec-mqtt,
                                     netty-codec-socks,
                                     netty-handler-proxy,
                                     <!-- api-plugins -->
@@ -684,6 +682,22 @@
                         </execution>
 
                         <!-- Linux Plugins -->
+                        <execution>
+                            <id>linux-plugins-3</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>copy-dependencies</goal>
+                            </goals>
+                            <configuration>
+                                <classifier>linux-${alt.native.tag}</classifier>
+                                <outputDirectory>${project.build.directory}/pkg/plugins/3</outputDirectory>
+                                <skip>${exclude.linux.plugins}</skip>
+                                <includeArtifactIds>
+                                    netty-transport-native-unix-common,
+                                    netty-transport-native-epoll
+                                </includeArtifactIds>
+                            </configuration>
+                        </execution>
                         <execution>
                             <id>linux-plugins-4</id>
                             <phase>generate-sources</phase>

--- a/kura/distrib/x86_64-core/pom.xml
+++ b/kura/distrib/x86_64-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Eurotech and/or its affiliates and others
+    Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/x86_64-core/pom.xml
+++ b/kura/distrib/x86_64-core/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <kura.basedir>../</kura.basedir>
         <kura.arch>x86_64</kura.arch>
+        <alt.native.tag>x86_64</alt.native.tag>
         <target.device>${kura.arch}</target.device>
         <arch>${kura.arch}</arch>
         <deb.name>kura-core</deb.name>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -375,6 +375,18 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${io.netty.version}</version>
+                <classifier>linux-aarch_64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${io.netty.version}</version>
+                <classifier>linux-x86_64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-transport-classes-epoll</artifactId>
                 <version>${io.netty.version}</version>
             </dependency>
@@ -387,6 +399,18 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-kqueue</artifactId>
                 <version>${io.netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${io.netty.version}</version>
+                <classifier>linux-aarch_64</classifier>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${io.netty.version}</version>
+                <classifier>linux-x86_64</classifier>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
This PR adds the native versions of `netty-transport-native-unix-common` and `netty-transport-native-epoll` to the respective distrib builds.

`netty-transport-kqueue` have been removed from distrib since those are specific to `osx`.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
