### PR TITLE
feat(api): add KuraErrorCode.AUTHENTICATION_FAILED and KuraAuthenticationFailedException

### DIFF
--- a/kura/org.eclipse.kura.api/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.api/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.kura.api;singleton:=true
 Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=21))"
-Export-Package: org.eclipse.kura;version="1.7.0",
+Export-Package: org.eclipse.kura;version="1.8.0",
  org.eclipse.kura.ai.inference;version="1.1.0",
  org.eclipse.kura.annotation;version="1.0.0",
  org.eclipse.kura.asset;version="1.0.0",

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/KuraAuthenticationFailedException.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/KuraAuthenticationFailedException.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * KuraAuthenticationFailedException is raised when an authentication failure occurs.
+ * 
+ * @noextend This class is not intended to be subclassed by clients.
+ * @since 3.0
+ */
+@ProviderType
+public class KuraAuthenticationFailedException extends KuraException {
+
+    private static final long serialVersionUID = 7468903237373092296L;
+
+    public KuraAuthenticationFailedException(Throwable cause, String message) {
+        super(KuraErrorCode.AUTHENTICATION_FAILED, cause, message);
+    }
+
+    public KuraAuthenticationFailedException(String message) {
+        super(KuraErrorCode.AUTHENTICATION_FAILED, null, message);
+    }
+
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/KuraErrorCode.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/KuraErrorCode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -253,5 +253,11 @@ public enum KuraErrorCode {
      * 
      * @since 2.4
      */
-    INVALID_CERTIFICATE_EXCEPTION
+    INVALID_CERTIFICATE_EXCEPTION,
+    /**
+     * Authentication failed: {0}.
+     * 
+     * @since 3.0
+     */
+    AUTHENTICATION_FAILED
 }

--- a/kura/org.eclipse.kura.api/src/main/resources/org/eclipse/kura/core/messages/KuraExceptionMessagesBundle.properties
+++ b/kura/org.eclipse.kura.api/src/main/resources/org/eclipse/kura/core/messages/KuraExceptionMessagesBundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
 # 
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -57,3 +57,4 @@ BAD_REQUEST=Bad request. {0}
 NOT_FOUND=Not found.
 SERVICE_UNAVAILABLE=Service unavailable. {0}.
 DISCONNECTION_FAILED=Disconnection failed.
+AUTHENTICATION_FAILED=Authentication failed: {0}.


### PR DESCRIPTION
This PR adds a new error code for authentication failures, adds a new exception that wraps such error code, adds the relative message, and bumps the minor version of the exported package `org.eclipse.kura`.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
