### PR TITLE
feat(api): add org.eclipse.kura.security.token APIs

### DIFF
--- a/kura/org.eclipse.kura.api/bnd.bnd
+++ b/kura/org.eclipse.kura.api/bnd.bnd
@@ -86,6 +86,7 @@ Export-Package: \
     org.eclipse.kura.security;version="1.3.0",\
     org.eclipse.kura.security.keystore;version="1.2.0",\
     org.eclipse.kura.security.tamper.detection;version="1.0.0",\
+    org.eclipse.kura.security.token;version="1.0.0",\
     org.eclipse.kura.ssl;version="2.1.0",\
     org.eclipse.kura.status;version="1.0.2",\
     org.eclipse.kura.system;version="1.9.0",\

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenIssueRequest.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenIssueRequest.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.security.token;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Describes the token a caller wants issued.
+ * 
+ * @since 3.0
+ */
+public final class TokenIssueRequest {
+
+    private final String identityName;
+    private final Instant expiresAt;
+    private final Instant notBefore;
+    private final Set<String> intendedConsumers;
+    private final Map<String, Object> claims;
+
+    private TokenIssueRequest(final Builder builder) {
+        this.identityName = builder.identityName;
+        this.expiresAt = builder.expiresAt;
+        this.notBefore = builder.notBefore;
+        this.intendedConsumers = Collections.unmodifiableSet(new LinkedHashSet<>(builder.intendedConsumers));
+        this.claims = Collections.unmodifiableMap(new LinkedHashMap<>(builder.claims));
+    }
+
+    /**
+     * 
+     * @return the identity name for this request, cannot be {@code null}, empty or whitespace-only
+     */
+    public String getIdentityName() {
+        return this.identityName;
+    }
+
+    /**
+     * 
+     * @return the requested expiration instant, if present
+     */
+    public Optional<Instant> getExpiresAt() {
+        return Optional.ofNullable(this.expiresAt);
+    }
+
+    /**
+     * 
+     * @return the requested not before instant, if present
+     */
+    public Optional<Instant> getNotBefore() {
+        return Optional.ofNullable(this.notBefore);
+    }
+
+    /**
+     * 
+     * @return an unmodifiable set of the requested consumers, cannot be {@code null}. The returned set can be empty if
+     *         no explicit consumers were requested. Set entries cannot be {@code null}, nor empty, nor whitespace-only
+     *         {@link String}
+     */
+    public Set<String> getIntendedConsumers() {
+        return this.intendedConsumers;
+    }
+
+    /**
+     * 
+     * @return an unmodifiable map of the requested claims, cannot be {@code null}. The returned map can be empty if
+     *         no claims were requested. Map keys cannot be {@code null}, nor empty, nor whitespace-only {@link String}.
+     *         Supported claim values depend on the implementation
+     */
+    public Map<String, Object> getClaims() {
+        return this.claims;
+    }
+
+    /**
+     * 
+     * @return a {@link Builder} for constructing a {@link TokenIssueRequest}. When building a request, the
+     *         {@link Builder#identityName(String)} is mandatory
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String identityName;
+        private Instant expiresAt;
+        private Instant notBefore;
+        private final Set<String> intendedConsumers = new LinkedHashSet<>();
+        private final Map<String, Object> claims = new LinkedHashMap<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the Kura identity name that identifies the identity the request is issued for. This property is
+         * mandatory. Calling this method again overwrites any previously set identity.
+         *
+         * @param identityName
+         *            the name of the identity, must not be {@code null}, empty or whitespace-only
+         * @return this builder instance, for method chaining
+         * @throws NullPointerException
+         *             if {@code identityName} is {@code null}
+         * @throws IllegalArgumentException
+         *             if {@code identityName} is empty or whitespace-only
+         */
+        public Builder identityName(final String identityName) {
+            this.identityName = ensureNotNullNotBlank(identityName, "identityName");
+            return this;
+        }
+
+        /**
+         * Sets the instant at which the request expires. This property is optional.
+         *
+         * <p>
+         * The value is an absolute point in time; once it has passed, the request is no longer considered valid.
+         * Calling this method again overwrites any previously set expiration.
+         *
+         * @param expiresAt
+         *            the expiration instant, must not be {@code null}
+         * @return this builder instance, for method chaining
+         * @throws NullPointerException
+         *             if {@code expiresAt} is {@code null}
+         */
+        public Builder expiresAt(final Instant expiresAt) {
+            this.expiresAt = Objects.requireNonNull(expiresAt, "expiresAt cannot be null");
+            return this;
+        }
+
+        /**
+         * Sets the instant before which the request must not be accepted. This property is optional.
+         *
+         * <p>
+         * The value is an absolute point in time, inclusive: the request becomes valid at this instant. Calling this
+         * method again overwrites any previously set value.
+         *
+         * @param notBefore
+         *            the earliest instant at which the request is valid, must not be {@code null}
+         * @return this builder instance, for method chaining
+         * @throws NullPointerException
+         *             if {@code notBefore} is {@code null}
+         * @see #expiresAt(Instant)
+         */
+        public Builder notBefore(final Instant notBefore) {
+            this.notBefore = Objects.requireNonNull(notBefore, "notBefore cannot be null");
+            return this;
+        }
+
+        /**
+         * Adds an intended consumer of the token to this request. This property is optional.
+         * 
+         * <p>
+         * Call this method again to add multiple intended consumers to the request.
+         * 
+         * <p>
+         * Purpose of specifying an intended consumer is that a token consumer (like a token verifier) can reject the
+         * presented token if it is not for him.
+         * 
+         * @param consumer
+         *            the consumer name, cannot be {@code null}, empty or whitespace-only
+         * @return this builder instance, for method chaining
+         * @throws NullPointerException
+         *             if {@code consumer} is {@code null}
+         * @throws IllegalArgumentException
+         *             if {@code consumer} is empty or whitespace-only
+         */
+        public Builder intendedConsumer(String consumer) {
+            this.intendedConsumers.add(ensureNotNullNotBlank(consumer, "consumer"));
+            return this;
+        }
+
+        /**
+         * Sets a claim in the generic form of key-value pair. This property is optional.
+         * 
+         * <p>
+         * Call this method again to add multiple claims to the request. When called on a claim with the same name, its
+         * value gets updated.
+         * 
+         * @param name
+         *            the claim name, cannot be {@code null}, empty or whitespace-only
+         * @param value
+         *            the claim value, supported claim values depend on the implementation
+         * @return this builder instance, for method chaining
+         * @throws NullPointerException
+         *             if {@code name} is {@code null}
+         * @throws IllegalArgumentException
+         *             if {@code name} is empty or whitespace-only
+         */
+        public Builder claim(String name, Object value) {
+            final String key = ensureNotNullNotBlank(name, "name");
+            this.claims.put(key, value);
+            return this;
+        }
+
+        /**
+         * Builds a {@link TokenIssueRequest}.
+         * 
+         * @return
+         * @throws IllegalStateException
+         *             if the identityName has not been set
+         */
+        public TokenIssueRequest build() {
+            if (this.identityName == null) {
+                throw new IllegalStateException("TokenIssueRequest requires the identityName to be set");
+            }
+            return new TokenIssueRequest(this);
+        }
+
+        private static String ensureNotNullNotBlank(final String value, final String parameterName) {
+            final String result = Objects.requireNonNull(value, parameterName + " cannot be null");
+            if (result.isBlank()) {
+                throw new IllegalArgumentException(parameterName + " cannot be empty or whitespace-only");
+            }
+            return result;
+        }
+    }
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenIssueRequest.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenIssueRequest.java
@@ -87,40 +87,39 @@ public final class TokenIssueRequest {
     }
 
     /**
+     * Get a builder for constructing a {@link TokenIssueRequest} with the identity name that
+     * the request should be issued for.
      * 
-     * @return a {@link Builder} for constructing a {@link TokenIssueRequest}. When building a request, the
-     *         {@link Builder#identityName(String)} is mandatory
+     * @param identityName
+     *            the name of the identity, must not be {@code null}, empty or whitespace-only
+     * @return a {@link Builder} for constructing a {@link TokenIssueRequest}
+     * @throws NullPointerException
+     *             if {@code identityName} is {@code null}
+     * @throws IllegalArgumentException
+     *             if {@code identityName} is empty or whitespace-only
      */
-    public static Builder builder() {
-        return new Builder();
+    public static Builder builder(final String identityName) {
+        return new Builder(ensureNotNullNotBlank(identityName, "identityName"));
+    }
+
+    private static String ensureNotNullNotBlank(final String value, final String parameterName) {
+        final String result = Objects.requireNonNull(value, parameterName + " cannot be null");
+        if (result.isBlank()) {
+            throw new IllegalArgumentException(parameterName + " cannot be empty or whitespace-only");
+        }
+        return result;
     }
 
     public static final class Builder {
 
-        private String identityName;
+        private final String identityName;
         private Instant expiresAt;
         private Instant notBefore;
         private final Set<String> intendedConsumers = new LinkedHashSet<>();
         private final Map<String, Object> claims = new LinkedHashMap<>();
 
-        private Builder() {
-        }
-
-        /**
-         * Sets the Kura identity name that identifies the identity the request is issued for. This property is
-         * mandatory. Calling this method again overwrites any previously set identity.
-         *
-         * @param identityName
-         *            the name of the identity, must not be {@code null}, empty or whitespace-only
-         * @return this builder instance, for method chaining
-         * @throws NullPointerException
-         *             if {@code identityName} is {@code null}
-         * @throws IllegalArgumentException
-         *             if {@code identityName} is empty or whitespace-only
-         */
-        public Builder identityName(final String identityName) {
-            this.identityName = ensureNotNullNotBlank(identityName, "identityName");
-            return this;
+        private Builder(final String identityName) {
+            this.identityName = identityName;
         }
 
         /**
@@ -209,23 +208,10 @@ public final class TokenIssueRequest {
         /**
          * Builds a {@link TokenIssueRequest}.
          * 
-         * @return
-         * @throws IllegalStateException
-         *             if the identityName has not been set
+         * @return a {@link TokenIssueRequest}
          */
         public TokenIssueRequest build() {
-            if (this.identityName == null) {
-                throw new IllegalStateException("TokenIssueRequest requires the identityName to be set");
-            }
             return new TokenIssueRequest(this);
-        }
-
-        private static String ensureNotNullNotBlank(final String value, final String parameterName) {
-            final String result = Objects.requireNonNull(value, parameterName + " cannot be null");
-            if (result.isBlank()) {
-                throw new IllegalArgumentException(parameterName + " cannot be empty or whitespace-only");
-            }
-            return result;
         }
     }
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenIssuingService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenIssuingService.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.security.token;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.eclipse.kura.KuraException;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * Service that issues authentication tokens.
+ * 
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @since 3.0
+ */
+@ProviderType
+public interface TokenIssuingService {
+
+    /**
+     * The configured upper bound on the lifetime of issued tokens.
+     * 
+     * @return the maximum lifetime, empty if any lifetime is accepted
+     */
+    public Optional<Duration> getMaximumLifetime();
+
+    /**
+     * Issues a new token for the identity and validity window described by the given request.
+     *
+     * <p>
+     * Each invocation issues a distinct token: this method is not idempotent, and calling it twice with equal requests
+     * yields two independently valid tokens.
+     *
+     * <p>
+     * The returned value is a credential and should be treated as a secret. It must not be logged, and it is the
+     * caller's responsibility to transport it over a secured channel.
+     *
+     * @param request
+     *            the parameters of the token to be issued, must not be
+     *            {@code null}
+     * @return the encoded token, never {@code null} nor empty
+     * @throws KuraException
+     *             if the token cannot be issued
+     * @throws NullPointerException
+     *             if {@code request} is {@code null}
+     */
+    public String issue(final TokenIssueRequest request) throws KuraException;
+
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenVerificationService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenVerificationService.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.security.token;
+
+import org.eclipse.kura.KuraException;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * Service that verifies authentication tokens.
+ * 
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @since 3.0
+ */
+@ProviderType
+public interface TokenVerificationService {
+
+    /**
+     * Verifies a token.
+     *
+     * @param request
+     *            the verification request, carrying the encoded token and the constraints to be enforced, must not be
+     *            {@code null}
+     * @return the proof of verification describing the verified identity and the properties of the token, never
+     *         {@code null}
+     * @throws KuraException
+     *             if verification fails for any reason. If authentication fails, it is a
+     *             {@link org.eclipse.kura.KuraAuthenticationFailedException}
+     */
+    public VerificationProof verify(final TokenVerifyRequest request) throws KuraException;
+
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenVerifyRequest.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenVerifyRequest.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.security.token;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Describes what the caller wants to verify on the token.
+ * 
+ * @since 3.0
+ */
+public final class TokenVerifyRequest {
+
+    private final String token;
+    private final String intendedConsumer;
+
+    private TokenVerifyRequest(final Builder builder) {
+        this.token = builder.token;
+        this.intendedConsumer = builder.intendedConsumer;
+    }
+
+    /**
+     * 
+     * @return the encoded token associated with this request, cannot be {@code null}, or empty, or whitespace-only
+     */
+    public String getToken() {
+        return this.token;
+    }
+
+    /**
+     * 
+     * @return the intended consumer for the presented token, so that token verifier can reject the presented token if
+     *         it is not for him, cannot be {@code null}
+     */
+    public Optional<String> getIntendedConsumer() {
+        return Optional.ofNullable(this.intendedConsumer);
+    }
+
+    /**
+     * 
+     * @return a {@link Builder} for constructing a {@link TokenVerifyRequest}. When building a request, the
+     *         {@link Builder#token(String)} is mandatory
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String token;
+        private String intendedConsumer;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the encoded token to be verified. This property is mandatory.
+         *
+         * @param token
+         *            the encoded token to be verified, must not be {@code null}, nor empty, nor whitespace-only
+         * @return this builder instance, for method chaining
+         * @throws NullPointerException
+         *             if the provided token is {@code null}
+         * @throws IllegalArgumentException
+         *             if {@code token} is empty or whitespace-only
+         */
+        public Builder token(final String token) {
+            this.token = ensureNotNullNotBlank(token, "token");
+            return this;
+        }
+
+        /**
+         * Sets the identifier of the component that is presenting the token for use. This property is optional.
+         *
+         * <p>
+         * When set, verification succeeds only if the token was issued for use by the specified consumer. This prevents
+         * a token obtained by one component from being replayed against a different, possibly more privileged, one.
+         * </p>
+         *
+         * <p>
+         * If this property is left unset, no consumer constraint is enforced and a token issued for any consumer is
+         * accepted.
+         * </p>
+         *
+         * @param intendedConsumer
+         *            the identifier of the component presenting the token, must not be {@code null}, empty or
+         *            whitespace-only
+         * @return this builder instance, for method chaining
+         * @throws NullPointerException
+         *             if the provided intendedConsumer is {@code null}
+         * @throws IllegalArgumentException
+         *             if {@code intendedConsumer} is empty or whitespace-only
+         */
+        public Builder intendedConsumer(final String intendedConsumer) {
+            this.intendedConsumer = ensureNotNullNotBlank(intendedConsumer, "intendedConsumer");
+            return this;
+        }
+
+        /**
+         * Builds a {@link TokenVerifyRequest}.
+         * 
+         * @return
+         * @throws IllegalStateException
+         *             if the token has not been set
+         */
+        public TokenVerifyRequest build() {
+            if (this.token == null) {
+                throw new IllegalStateException("TokenVerifyRequest requires the token to be set");
+            }
+
+            return new TokenVerifyRequest(this);
+        }
+
+        private static String ensureNotNullNotBlank(final String value, final String parameterName) {
+            final String result = Objects.requireNonNull(value, parameterName + " cannot be null");
+            if (result.isBlank()) {
+                throw new IllegalArgumentException(parameterName + " cannot be empty or whitespace-only");
+            }
+            return result;
+        }
+
+    }
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenVerifyRequest.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/TokenVerifyRequest.java
@@ -48,36 +48,35 @@ public final class TokenVerifyRequest {
     }
 
     /**
+     * Get a builder for constructing a {@link TokenVerifyRequest} with the token that needs to be verified.
      * 
-     * @return a {@link Builder} for constructing a {@link TokenVerifyRequest}. When building a request, the
-     *         {@link Builder#token(String)} is mandatory
+     * @param token
+     *            the encoded token to be verified, must not be {@code null}, nor empty, nor whitespace-only
+     * @return a {@link Builder} for constructing a {@link TokenVerifyRequest}
+     * @throws NullPointerException
+     *             if the provided token is {@code null}
+     * @throws IllegalArgumentException
+     *             if {@code token} is empty or whitespace-only
      */
-    public static Builder builder() {
-        return new Builder();
+    public static Builder builder(final String token) {
+        return new Builder(ensureNotNullNotBlank(token, "token"));
+    }
+
+    private static String ensureNotNullNotBlank(final String value, final String parameterName) {
+        final String result = Objects.requireNonNull(value, parameterName + " cannot be null");
+        if (result.isBlank()) {
+            throw new IllegalArgumentException(parameterName + " cannot be empty or whitespace-only");
+        }
+        return result;
     }
 
     public static final class Builder {
 
-        private String token;
+        private final String token;
         private String intendedConsumer;
 
-        private Builder() {
-        }
-
-        /**
-         * Sets the encoded token to be verified. This property is mandatory.
-         *
-         * @param token
-         *            the encoded token to be verified, must not be {@code null}, nor empty, nor whitespace-only
-         * @return this builder instance, for method chaining
-         * @throws NullPointerException
-         *             if the provided token is {@code null}
-         * @throws IllegalArgumentException
-         *             if {@code token} is empty or whitespace-only
-         */
-        public Builder token(final String token) {
-            this.token = ensureNotNullNotBlank(token, "token");
-            return this;
+        private Builder(final String token) {
+            this.token = token;
         }
 
         /**
@@ -110,24 +109,10 @@ public final class TokenVerifyRequest {
         /**
          * Builds a {@link TokenVerifyRequest}.
          * 
-         * @return
-         * @throws IllegalStateException
-         *             if the token has not been set
+         * @return a {@link TokenVerifyRequest}
          */
         public TokenVerifyRequest build() {
-            if (this.token == null) {
-                throw new IllegalStateException("TokenVerifyRequest requires the token to be set");
-            }
-
             return new TokenVerifyRequest(this);
-        }
-
-        private static String ensureNotNullNotBlank(final String value, final String parameterName) {
-            final String result = Objects.requireNonNull(value, parameterName + " cannot be null");
-            if (result.isBlank()) {
-                throw new IllegalArgumentException(parameterName + " cannot be empty or whitespace-only");
-            }
-            return result;
         }
 
     }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/VerificationProof.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/VerificationProof.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.security.token;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * The outcome of a successful verification.
+ *
+ * <p>
+ * Holding an instance of this type <em>is</em> the proof that verification succeeded.
+ * </p>
+ *
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @since 3.0
+ */
+@ProviderType
+public interface VerificationProof {
+
+    /**
+     * Returns the identity name bound to the token.
+     *
+     * @return the identity name the token is bound to, cannot be {@code null}, empty or whitespace-only
+     */
+    public String getIdentityName();
+
+    /**
+     * Returns the instant at which verification ran.
+     *
+     * @return the instant at which verification ran, as seen by the verifier clock, cannot be {@code null}
+     */
+    public Instant getVerifiedAt();
+
+    /**
+     * Returns the instant after which the verified token is no longer valid.
+     *
+     * <p>
+     * The expiration was checked as part of verification and had not been reached at {@link #getVerifiedAt()}. It is
+     * reported here so that callers can decide when to obtain a fresh token, and to bound how long this instance may be
+     * retained.
+     * </p>
+     *
+     * <p>
+     * An empty value means the token carries no intrinsic expiration. Callers should treat such tokens with additional
+     * care and must not retain this instance indefinitely on the strength of a missing expiration.
+     *
+     * @return the instant at which the verified token expires, or an empty {@link Optional} if the token does not
+     *         expire on its own, cannot be {@code null}
+     */
+    public Optional<Instant> getExpiresAt();
+
+    /**
+     * Returns the instant before which the verified token was not valid.
+     *
+     * <p>
+     * This constraint was checked as part of verification and had already been satisfied at {@link #getVerifiedAt()}.
+     * The value is reported for informational and auditing purposes.
+     *
+     * @return the instant from which the verified token became valid, or an empty {@link Optional} if the token
+     *         declares no such constraint, cannot be {@code null}
+     */
+    public Optional<Instant> getNotBefore();
+
+    /**
+     * Returns the instant at which the verified token was issued.
+     *
+     * @return the instant at which the verified token was issued, or an empty {@link Optional} if the token does not
+     *         record it, cannot be {@code null}
+     */
+    public Optional<Instant> getIssuedAt();
+
+    /**
+     * Returns the identifier of the verified token.
+     *
+     * <p>
+     * It is intended for correlating issuance.
+     *
+     * @return the identifier of the verified token, or an empty {@link Optional} if the implementation does not assign
+     *         one, cannot be {@code null}
+     */
+    public Optional<String> getTokenID();
+
+    /**
+     * Returns the claims of the verified token.
+     * 
+     * <p>
+     * Depending on the implementation, the returned map may or may not contain the claims that can be accessed by the
+     * other methods of this interface, like {@link VerificationProof#getTokenID()} or
+     * {@link VerificationProof#getExpiresAt()}.
+     * 
+     * @return a map of the verified claims, cannot be {@code null}, can be empty. Map keys cannot be {@code null}, nor
+     *         empty, nor whitespace-only {@link String}. Supported claim values depend on the implementation
+     */
+    public Map<String, Object> getClaims();
+
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/package-info.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/token/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+/**
+ * Provides all the necessary APIs and classes for issuing and verifying authentication tokens
+ *
+ * @since 3.0
+ */
+package org.eclipse.kura.security.token;


### PR DESCRIPTION
This PR adds new APIs for implementing a Token Service and for verifying and issuing identity authentication tokens.

**Related Issue:** N/A.

**Description of the solution adopted:**

`TokenIssueRequest` does not take an `IdentityConfiguration` for identifying the Kura identity, but just the name. This is because the issuing and verification service do not need to query the `IdentityService`, these services just issue tokens and verify their validity. In my opinion, the query to the identity service to verify the identity exists should be done by another service (like an hypotetical REST JWT auth service).

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
