### PR TITLE
docs: add CLAUDE.md importing AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Add a `CLAUDE.md` at the repository root containing a single `@AGENTS.md` import, so that Claude Code picks up the agent guide we already maintain in `AGENTS.md`.

## Why

Claude Code reads `CLAUDE.md`, not `AGENTS.md`, so today the contents of `AGENTS.md` are simply ignored by it while other agents do read them. The [documented way](https://code.claude.com/docs/en/memory) to reconcile the two is a `CLAUDE.md` that imports the existing file:

```markdown
@AGENTS.md
```

Imports are expanded into context at session start, with relative paths resolved against the importing file.

## Notes

- Deliberately a one-line import rather than a copy or a filesystem symlink: `AGENTS.md` remains the single source of truth, nothing can drift out of sync, and the file works on checkouts where symlinks are not materialized.
- Claude Code accepts the file at either `./CLAUDE.md` or `./.claude/CLAUDE.md`; the repository root was chosen for visibility, next to `AGENTS.md`.
- Any future Claude-Code-specific guidance can be appended below the import line without affecting other agents.

## Testing

Documentation-only change — no build, no code, no runtime behaviour is affected.
