### PR TITLE
ci: correctly pass token to backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,3 +12,5 @@ permissions:
 jobs:
   call-workflow-in-public-repo:
     uses: eclipse-kura/.github/.github/workflows/_shared-backport.yml@main
+    secrets:
+      personal_access_token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Follows https://github.com/eclipse-kura/.github/pull/35