### PR TITLE
docs: clarify persisted database path must target data partition

### DIFF
--- a/docs/core-services/h2db-service.md
+++ b/docs/core-services/h2db-service.md
@@ -53,7 +53,7 @@ To create a new H2 database instance, use the following procedure:
 ### Configuration Parameters
 The **H2DbService** provides the following configuration parameters:
 
-* **Connector URL**: JDBC connector URL of the database instance.  Passing the USER and PASSWORD parameters in the connector URL is not supported, these paramters will be ignored if present. Please use the db.user and db.password fields to provide the credentials. If the database is persisted on disk, the path must be set to a location under the data partition, as defined by the specific target OS configuration, to ensure data is preserved across software updates and reboots.
+* **Connector URL**: JDBC connector URL of the database instance.  Passing the USER and PASSWORD parameters in the connector URL is not supported, these paramters will be ignored if present. Please use the db.user and db.password fields to provide the credentials. If the database is meant to be persisted on disk, the path must be set to a location designated for persistent storage by the target OS configuration, to ensure data is preserved across software updates and reboots.
 
 !!! warning
     If the database is created in persisted mode, please make sure that the Linux user running Eclipse Kura has the permissions required to create the database file.

--- a/docs/core-services/h2db-service.md
+++ b/docs/core-services/h2db-service.md
@@ -53,7 +53,7 @@ To create a new H2 database instance, use the following procedure:
 ### Configuration Parameters
 The **H2DbService** provides the following configuration parameters:
 
-* **Connector URL**: JDBC connector URL of the database instance.  Passing the USER and PASSWORD parameters in the connector URL is not supported, these paramters will be ignored if present. Please use the db.user and db.password fields to provide the credentials. 
+* **Connector URL**: JDBC connector URL of the database instance.  Passing the USER and PASSWORD parameters in the connector URL is not supported, these paramters will be ignored if present. Please use the db.user and db.password fields to provide the credentials. If the database is persisted on disk, the path must be set to a location under the data partition, as defined by the specific target OS configuration, to ensure data is preserved across software updates and reboots.
 
 !!! warning
     If the database is created in persisted mode, please make sure that the Linux user running Eclipse Kura has the permissions required to create the database file.
@@ -172,7 +172,7 @@ The default database instance is in-memory by default and uses the **jdbc:h2:mem
 
 ### Persistent
 
-A persistent database instance can be created using the **jdbc:h2:file:<dbpath>**, where **<dbpath>** is a non-empty string that represents the database path.
+A persistent database instance can be created using the **jdbc:h2:file:<dbpath>**, where **<dbpath>** is a non-empty string that represents the database path. The path must be set to a location under the data partition, as defined by the specific target OS configuration, to ensure data is preserved across software updates and reboots.
 
 If no URL parameters are supplied the database will enable the transaction log by default. The transaction log is used to restore the database to a consistent state after a crash or power failure. This provides good protection against data losses but causes a lot of writes to the storage device, reducing both performance and the lifetime of flash-based storage devices.
 

--- a/docs/core-services/h2db-service.md
+++ b/docs/core-services/h2db-service.md
@@ -172,7 +172,7 @@ The default database instance is in-memory by default and uses the **jdbc:h2:mem
 
 ### Persistent
 
-A persistent database instance can be created using the **jdbc:h2:file:<dbpath>**, where **<dbpath>** is a non-empty string that represents the database path. The path must be set to a location under the data partition, as defined by the specific target OS configuration, to ensure data is preserved across software updates and reboots.
+A persistent database instance can be created using the **jdbc:h2:file:<dbpath>**, where **<dbpath>** is a non-empty string that represents the database path. The path must be set to a location designated for persistent storage by the target OS configuration, to ensure data is preserved across software updates and reboots.
 
 If no URL parameters are supplied the database will enable the transaction log by default. The transaction log is used to restore the database to a consistent state after a crash or power failure. This provides good protection against data losses but causes a lot of writes to the storage device, reducing both performance and the lifetime of flash-based storage devices.
 

--- a/docs/core-services/sqlite-db-service.md
+++ b/docs/core-services/sqlite-db-service.md
@@ -31,7 +31,7 @@ The SQLite DB provides the following configuration parameters:
 
 * **Database Mode**: Defines the database mode. If `In Memory` is selected, the database will not be persisted on the filesystem, all data will be lost if Kura is restarted and/or the database instance is deleted. If `Persisted` is selected, the database will be stored on disk in the location specified by the **Persisted Database Path** parameter.
 
-* **Persisted Database Path**: Defines the path to the database file (it must include the database file name). This parameter is only relevant for persisted databases.
+* **Persisted Database Path**: Defines the path to the database file (it must include the database file name). This parameter is only relevant for persisted databases. If the database is persisted on disk, the path must be set to a location under the data partition, as defined by the specific target OS configuration, to ensure data is preserved across software updates and reboots.
 
 * **Encryption Key**: Allows to specify a key/passphrase for encrypting the database file. This feature requires a SQLite binary with an encryption extension, and is only relevant for persisted databases. The key format can be specified using the **Encryption Key Format** parameter. If the value of this parameter is changed, the encryption key of the database will be updated accordingly. This parameter can be left empty to create an unencrypted database or to decrypt an encrypted one.
 

--- a/docs/core-services/sqlite-db-service.md
+++ b/docs/core-services/sqlite-db-service.md
@@ -31,7 +31,7 @@ The SQLite DB provides the following configuration parameters:
 
 * **Database Mode**: Defines the database mode. If `In Memory` is selected, the database will not be persisted on the filesystem, all data will be lost if Kura is restarted and/or the database instance is deleted. If `Persisted` is selected, the database will be stored on disk in the location specified by the **Persisted Database Path** parameter.
 
-* **Persisted Database Path**: Defines the path to the database file (it must include the database file name). This parameter is only relevant for persisted databases. If the database is persisted on disk, the path must be set to a location under the data partition, as defined by the specific target OS configuration, to ensure data is preserved across software updates and reboots.
+* **Persisted Database Path**: Defines the path to the database file (it must include the database file name). This parameter is only relevant for persisted databases. If the database is meant to be persisted on disk, the path must be set to a location designated for persistent storage by the target OS configuration, to ensure data is preserved across software updates and reboots.
 
 * **Encryption Key**: Allows to specify a key/passphrase for encrypting the database file. This feature requires a SQLite binary with an encryption extension, and is only relevant for persisted databases. The key format can be specified using the **Encryption Key Format** parameter. If the value of this parameter is changed, the encryption key of the database will be updated accordingly. This parameter can be left empty to create an unencrypted database or to decrypt an encrypted one.
 


### PR DESCRIPTION
## Summary
- Clarifies in the H2Db and SQLite DB service documentation that when a database instance is persisted on disk, its path must be set to a location under the data partition, as defined by the specific target OS configuration, so data survives software updates and reboots.
- Companion to #6329, which made the equivalent clarification in the H2DbService/SQLiteDbService metatype descriptions.

## Test plan
- [x] Reviewed rendered Markdown changes for correctness