### PR TITLE
docs(distrib): record CVE-2026-54399 as no issue for 5.6.3

### DIFF
--- a/kura/distrib/RELEASE_NOTES.txt
+++ b/kura/distrib/RELEASE_NOTES.txt
@@ -1,3 +1,13 @@
+Eclipse Kura - 5.6.3 - TBD
+-------------------------------------------------------------------------------------------------
+Security Fixes:
+  * CVE-2026-54399 - no issue: httpcore5 and httpcore5-h2 are embedded in
+    org.eclipse.kura.container.orchestration.provider on the bundle class path only. They are
+    not exported, no other bundle imports them, and no Kura component uses them in a server
+    role, so the HTTP/1.1 message parser affected by this vulnerability is never exposed to
+    untrusted input. No dependency update is required on this branch.
+
+
 Eclipse Kura - 5.6.2 - June 2026
 -------------------------------------------------------------------------------------------------
 Description:


### PR DESCRIPTION
Records the outcome of the CVE-2026-54399 triage in the release notes, so the decision not to update the dependency on this branch is traceable from the repository.

`httpcore5` and `httpcore5-h2` are embedded in `org.eclipse.kura.container.orchestration.provider` on the bundle class path only: they are not exported, no other bundle imports them, and no Kura component uses them in a server role. The HTTP/1.1 message parser affected by the vulnerability therefore never sees untrusted input, so no dependency update is required on 5.6.x.

There was no existing section for this kind of assessment on this branch, and no 5.6.3 section at all, so this opens one with a `Security Fixes:` entry, in the same shape the 5.6.2 section was started with. The rest of the 5.6.3 section is left to the usual release-notes pass.