### PR TITLE
ci(Jenkinsfile): fix OOMKill during builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,3 +92,4 @@ node(POD_LABEL) {
         }
     }
 }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,4 @@
-podTemplate(inheritFrom: 'basic', yaml: '''
-spec:
-  containers:
-  - name: "jnlp"
-    resources:
-      limits:
-        cpu: "2000m"
-        memory: "5Gi"
-      requests:
-        cpu: "1000m"
-        memory: "3Gi"
-''') {
-node(POD_LABEL) {
+node {
     properties([
         disableConcurrentBuilds(abortPrevious: true),
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2', daysToKeepStr: '', numToKeepStr: '3')),
@@ -91,5 +79,4 @@ node(POD_LABEL) {
             }
         }
     }
-}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 node {
     properties([
         disableConcurrentBuilds(abortPrevious: true),
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2', daysToKeepStr: '', numToKeepStr: '5')),
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2', daysToKeepStr: '', numToKeepStr: '3')),
         gitLabConnection('gitlab.eclipse.org'),
         [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
         [$class: 'JobLocalConfiguration', changeReasonComment: '']
@@ -18,7 +18,7 @@ node {
     stage('Build') {
         timeout(time: 2, unit: 'HOURS') {
             dir("kura") {
-                withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.9.6') {
+                withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.9.6', options: [artifactsPublisher(disabled: true)]) {
                     sh "touch /tmp/isJenkins.txt"
                     sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin"
                     sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node(POD_LABEL) {
     stage('Build') {
         timeout(time: 2, unit: 'HOURS') {
             dir("kura") {
-                withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.9.6', options: [artifactsPublisher(disabled: true)]) {
+                withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.9.6', publisherStrategy: 'EXPLICIT') {
                     sh "touch /tmp/isJenkins.txt"
                     sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin"
                     sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,16 @@
-node {
+podTemplate(inheritFrom: 'basic', yaml: '''
+spec:
+  containers:
+  - name: "jnlp"
+    resources:
+      limits:
+        cpu: "2000m"
+        memory: "5Gi"
+      requests:
+        cpu: "1000m"
+        memory: "3Gi"
+''') {
+node(POD_LABEL) {
     properties([
         disableConcurrentBuilds(abortPrevious: true),
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2', daysToKeepStr: '', numToKeepStr: '3')),


### PR DESCRIPTION
Backport changes in #5877 to avoid issue reported in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/work_items/7807

The biggest change here is setting the `MavenPublisherStrategy` to `EXPLICIT`. This
- disables all .jar archival (more than 10k files were archived before this change)
- disables test result publishing on Jenkins. Before this change the test were counted 3 times. There's an explicit stage for gathering test results in the pipeline which already takes care of that

In summary: this PR improves our pipeline but I cannot state with confidence that it fixes the OOM Kill we were observing since it seems to have disappeared on its own.