### PR TITLE
fix(web2): support concurrent system log downloads [backport release-5.6.0]

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -92,28 +92,28 @@ public class LogTabUi extends Composite {
     private boolean autoFollow = true;
     private boolean initialized = false;
 
-    private final String nonce = Integer.toString(Random.nextInt());
+    private static final String COOKIE_NAME_PREFIX = "LogsDownload-";
+
+    // regenerated on every download, so that two downloads never share a completion cookie
+    private String nonce = newNonce();
 
     private static final int DOWNLOAD_COMPLETE_WAIT_TIMEOUT = 5000;
     private static final int DOWNLOAD_COMPLETION_RETRIES= 60; 
     
     private Timer waitDownloadCompleted = new Timer() {
 
-        // safety parameter, 9 = 45secs
+        // safety parameter, 60 retries every 5 seconds = 5 minutes
         private short retryLimit = DOWNLOAD_COMPLETION_RETRIES;
         private String cookieName;
 
         @Override
         public void run() {
-            cookieName = "LogsDownload-" + LogTabUi.this.nonce;
-
-            if (Cookies.getCookie(cookieName) != null) {
-                hideModalAndStop();
-            }
+            cookieName = COOKIE_NAME_PREFIX + LogTabUi.this.nonce;
 
             // eventually regain access to the UI
-            if (this.retryLimit <= 0) {
+            if (Cookies.getCookie(cookieName) != null || this.retryLimit <= 0) {
                 hideModalAndStop();
+                return;
             }
 
             this.retryLimit--;
@@ -145,6 +145,9 @@ public class LogTabUi extends Composite {
 
                     @Override
                     public void onSuccess(GwtXSRFToken token) {
+                        Cookies.removeCookie(COOKIE_NAME_PREFIX + LogTabUi.this.nonce, "/");
+                        LogTabUi.this.nonce = newNonce();
+
                         final StringBuilder sbUrl = new StringBuilder();
                         sbUrl.append("/log?nonce=").append(LogTabUi.this.nonce);
                         DownloadHelper.instance().startDownload(token, sbUrl.toString());
@@ -170,6 +173,10 @@ public class LogTabUi extends Composite {
         this.openNewWindow.addClickHandler(handler -> {
             Window.open(Window.Location.getHref(), "_blank", "");
         });
+    }
+
+    private static String newNonce() {
+        return Integer.toString(Random.nextInt(Integer.MAX_VALUE));
     }
 
     public void initialize() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/LogServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/LogServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,16 +15,24 @@ package org.eclipse.kura.web.server.servlet;
 import static java.util.Objects.isNull;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
@@ -54,9 +62,18 @@ public class LogServlet extends AuditServlet {
     private static final long serialVersionUID = 3969980124054250070L;
 
     private static Logger logger = LoggerFactory.getLogger(LogServlet.class);
-    private static final String KURA_JOURNAL_LOG_FILE = "/tmp/kura_journal.log";
-    private static final String SYSTEM_JOURNAL_LOG_FILE = "/tmp/system_journal.log";
+    private static final String KURA_JOURNAL_LOG_FILE_NAME = "kura_journal.log";
+    private static final String SYSTEM_JOURNAL_LOG_FILE_NAME = "system_journal.log";
+    private static final String TEMP_ZIP_FILE_NAME = "Kura_Logs.zip";
+    private static final String ARCHIVE_NAME_PREFIX = "Kura_Logs";
+    private static final String ARCHIVE_NAME_EXTENSION = ".zip";
+    private static final DateTimeFormatter ARCHIVE_NAME_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+    private static final Pattern UNSAFE_FILE_NAME_CHARS = Pattern.compile("[^A-Za-z0-9._-]+");
+    private static final int MAX_DEVICE_NAME_LENGTH = 40;
+    private static final String TEMP_DIR_PREFIX = "kura_logs_";
     private static final String JOURNALCTL_CMD = "journalctl";
+    private static final String COOKIE_NAME_PREFIX = "LogsDownload-";
+    private static final Pattern NONCE_PATTERN = Pattern.compile("-?[0-9]{1,32}");
 
     public LogServlet() {
         super("UI Log Download", "Download device logs");
@@ -77,12 +94,15 @@ public class LogServlet extends AuditServlet {
         }
         // END XSRF security check
 
+        String nonce = httpServletRequest.getParameter("nonce");
+
         SystemService ss = null;
         ServiceLocator locator = ServiceLocator.getInstance();
         try {
             ss = locator.getService(SystemService.class);
         } catch (GwtKuraException e1) {
             logger.warn("Unable to get service");
+            releaseClient(httpServletResponse, nonce);
             return;
         }
 
@@ -91,9 +111,30 @@ public class LogServlet extends AuditServlet {
             pes = locator.getService(PrivilegedExecutorService.class);
         } catch (GwtKuraException e1) {
             logger.warn("Unable to get service");
+            releaseClient(httpServletResponse, nonce);
             return;
         }
 
+        // Every request works in its own private temporary directory: concurrent downloads must not
+        // truncate, overwrite or delete each other's journal dumps and archives.
+        Path tempDir = null;
+        try {
+            tempDir = createPrivateTempDirectory();
+
+            List<File> fileList = collectLogFiles(ss);
+            fileList.addAll(collectJournalLogs(ss, pes, tempDir));
+
+            String archiveName = buildArchiveName(ss.getDeviceName(), LocalDateTime.now());
+            createReply(httpServletResponse, fileList, tempDir, nonce, archiveName);
+        } catch (IOException e) {
+            logger.warn("Unable to create zip file containing log resources", e);
+            releaseClient(httpServletResponse, nonce);
+        } finally {
+            deleteTempDirectory(tempDir);
+        }
+    }
+
+    private List<File> collectLogFiles(SystemService ss) {
         List<String> paths = new ArrayList<>();
 
         String logSourcesVal = ss.getProperties().getProperty("kura.log.download.sources", "/var/log");
@@ -112,72 +153,167 @@ public class LogServlet extends AuditServlet {
             }
         });
 
+        return fileList;
+    }
+
+    private List<File> collectJournalLogs(SystemService ss, PrivilegedExecutorService pes, Path tempDir) {
         String outputFields = ss.getProperties().getProperty("kura.log.download.journal.fields",
                 "SYSLOG_IDENTIFIER,PRIORITY,MESSAGE,STACKTRACE");
 
-        if (writeJournalLog(pes, outputFields, KURA_JOURNAL_LOG_FILE, "kura")) {
-            fileList.add(new File(KURA_JOURNAL_LOG_FILE));
+        List<File> journalFiles = new ArrayList<>();
+
+        Path kuraJournalLogFile = tempDir.resolve(KURA_JOURNAL_LOG_FILE_NAME);
+        if (writeJournalLog(pes, outputFields, kuraJournalLogFile.toString(), "kura")
+                && Files.isRegularFile(kuraJournalLogFile)) {
+            journalFiles.add(kuraJournalLogFile.toFile());
         } else {
-            logger.warn("Error producing: {}", KURA_JOURNAL_LOG_FILE);
+            logger.warn("Error producing: {}", kuraJournalLogFile);
         }
 
-        if (writeJournalLog(pes, outputFields, SYSTEM_JOURNAL_LOG_FILE)) {
-            fileList.add(new File(SYSTEM_JOURNAL_LOG_FILE));
+        Path systemJournalLogFile = tempDir.resolve(SYSTEM_JOURNAL_LOG_FILE_NAME);
+        if (writeJournalLog(pes, outputFields, systemJournalLogFile.toString())
+                && Files.isRegularFile(systemJournalLogFile)) {
+            journalFiles.add(systemJournalLogFile.toFile());
         } else {
-            logger.warn("Error producing: {}", SYSTEM_JOURNAL_LOG_FILE);
+            logger.warn("Error producing: {}", systemJournalLogFile);
         }
 
-        String nonce = httpServletRequest.getParameter("nonce");
-        createReply(httpServletResponse, fileList, nonce);
-        removeTmpFiles();
+        return journalFiles;
     }
 
-    private void createReply(HttpServletResponse httpServletResponse, List<File> fileList, String nonce) {
-        try {
-            byte[] zip = zipFiles(fileList);
-            ServletOutputStream sos = httpServletResponse.getOutputStream();
+    private void createReply(HttpServletResponse httpServletResponse, List<File> fileList, Path tempDir, String nonce,
+            String archiveName) throws IOException {
 
-            Cookie downloadedCookie = new Cookie("LogsDownload-" + nonce, "finished");
-            downloadedCookie.setPath("/");
-            httpServletResponse.addCookie(downloadedCookie);
-            httpServletResponse.setContentType("application/zip");
-            httpServletResponse.setHeader("Content-Disposition", "attachment; filename=\"Kura_Logs.zip\"");
-
-            sos.write(zip);
-            sos.flush();
-        } catch (IOException e) {
-            logger.warn("Unable to create zip file containing log resources");
+        // the archive is assembled on disk instead of in memory: /var/log can be arbitrarily large,
+        // and the completion cookie must be sent only once the archive is actually ready
+        Path zipPath = tempDir.resolve(TEMP_ZIP_FILE_NAME);
+        try (ZipOutputStream zos = new ZipOutputStream(
+                new BufferedOutputStream(Files.newOutputStream(zipPath)))) {
+            zipFiles(zos, fileList);
         }
+
+        addDownloadCompletedCookie(httpServletResponse, nonce);
+        httpServletResponse.setContentType("application/zip");
+        httpServletResponse.setHeader("Content-Disposition", "attachment; filename=\"" + archiveName + "\"");
+        httpServletResponse.setContentLengthLong(Files.size(zipPath));
+
+        ServletOutputStream sos = httpServletResponse.getOutputStream();
+        Files.copy(zipPath, sos);
+        sos.flush();
     }
 
-    private byte[] zipFiles(List<File> files) throws IOException {
+    /**
+     * Names the downloaded archive after the device and the moment it was taken, so that logs
+     * collected from several gateways, or from the same one at different times, stay distinguishable
+     * once downloaded.
+     */
+    String buildArchiveName(String deviceName, LocalDateTime timestamp) {
+        StringBuilder archiveName = new StringBuilder(ARCHIVE_NAME_PREFIX);
+
+        String sanitizedDeviceName = sanitizeForFileName(deviceName);
+        if (!sanitizedDeviceName.isEmpty()) {
+            archiveName.append('_').append(sanitizedDeviceName);
+        }
+
+        archiveName.append('_').append(ARCHIVE_NAME_TIMESTAMP.format(timestamp));
+
+        return archiveName.append(ARCHIVE_NAME_EXTENSION).toString();
+    }
+
+    String sanitizeForFileName(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String sanitized = UNSAFE_FILE_NAME_CHARS.matcher(value.trim()).replaceAll("_");
+
+        int start = 0;
+        while (start < sanitized.length() && isTrimmableFileNameChar(sanitized.charAt(start))) {
+            start++;
+        }
+        int end = sanitized.length();
+        while (end > start && isTrimmableFileNameChar(sanitized.charAt(end - 1))) {
+            end--;
+        }
+        sanitized = sanitized.substring(start, end);
+
+        return sanitized.length() > MAX_DEVICE_NAME_LENGTH ? sanitized.substring(0, MAX_DEVICE_NAME_LENGTH)
+                : sanitized;
+    }
+
+    private static boolean isTrimmableFileNameChar(char c) {
+        return c == '.' || c == '_' || c == '-';
+    }
+
+    /**
+     * Lets the client stop waiting when the archive cannot be produced: without the completion cookie
+     * the browser keeps the wait modal up until its own retry limit expires.
+     */
+    private void releaseClient(HttpServletResponse httpServletResponse, String nonce) {
+        if (httpServletResponse.isCommitted()) {
+            return;
+        }
+
+        addDownloadCompletedCookie(httpServletResponse, nonce);
+        httpServletResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    private void addDownloadCompletedCookie(HttpServletResponse httpServletResponse, String nonce) {
+        // the nonce ends up in a cookie name: an unexpected value would make the Cookie constructor throw
+        if (nonce == null || !NONCE_PATTERN.matcher(nonce).matches()) {
+            logger.warn("Invalid download nonce, the completion cookie will not be set");
+            return;
+        }
+
+        Cookie downloadedCookie = new Cookie(COOKIE_NAME_PREFIX + nonce, "finished");
+        downloadedCookie.setPath("/");
+        httpServletResponse.addCookie(downloadedCookie);
+    }
+
+    void zipFiles(ZipOutputStream zos, List<File> files) throws IOException {
         byte[] bytes = new byte[2048];
+        Set<String> usedEntryNames = new HashSet<>();
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                ZipOutputStream zos = new ZipOutputStream(baos);) {
-            for (File file : files) {
-                zipFile(bytes, zos, file);
+        for (File file : files) {
+            InputStream fileInput;
+            try {
+                fileInput = new BufferedInputStream(new FileInputStream(file));
+            } catch (IOException e) {
+                // a rotated or unreadable log file must not compromise the whole archive
+                logger.warn("Unable to read log file {}, skipping it", file.getAbsolutePath());
+                continue;
             }
-            zos.flush();
-            zos.close();
-            baos.flush();
-            return baos.toByteArray();
-        }
 
+            try (InputStream bis = fileInput) {
+                zos.putNextEntry(new ZipEntry(uniqueEntryName(usedEntryNames, file.getName())));
+
+                int bytesRead;
+                while ((bytesRead = bis.read(bytes)) != -1) {
+                    zos.write(bytes, 0, bytesRead);
+                }
+                zos.closeEntry();
+            }
+        }
     }
 
-    private void zipFile(byte[] bytes, ZipOutputStream zos, File file) throws IOException {
-        try (FileInputStream fis = new FileInputStream(file.getCanonicalPath());
-                BufferedInputStream bis = new BufferedInputStream(fis);) {
-
-            zos.putNextEntry(new ZipEntry(file.getName()));
-
-            int bytesRead;
-            while ((bytesRead = bis.read(bytes)) != -1) {
-                zos.write(bytes, 0, bytesRead);
-            }
-            zos.closeEntry();
+    String uniqueEntryName(Set<String> usedEntryNames, String fileName) {
+        if (usedEntryNames.add(fileName)) {
+            return fileName;
         }
+
+        // same file name coming from two different source directories
+        int dotIndex = fileName.lastIndexOf('.');
+        String baseName = dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
+        String extension = dotIndex > 0 ? fileName.substring(dotIndex) : "";
+
+        int suffix = 1;
+        String candidate;
+        do {
+            candidate = baseName + "_" + suffix + extension;
+            suffix++;
+        } while (!usedEntryNames.add(candidate));
+
+        return candidate;
     }
 
     private boolean writeJournalLog(PrivilegedExecutorService pes, String outputFields, String outputFile) {
@@ -213,12 +349,26 @@ public class LogServlet extends AuditServlet {
         return status.getExitStatus().isSuccessful();
     }
 
-    private void removeTmpFiles() {
-        try {
-            Files.deleteIfExists(new File(KURA_JOURNAL_LOG_FILE).toPath());
-            Files.deleteIfExists(new File(SYSTEM_JOURNAL_LOG_FILE).toPath());
+    Path createPrivateTempDirectory() throws IOException {
+        return Files.createTempDirectory(TEMP_DIR_PREFIX,
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    }
+
+    void deleteTempDirectory(Path tempDir) {
+        if (tempDir == null) {
+            return;
+        }
+
+        try (Stream<Path> tempDirStream = Files.walk(tempDir)) {
+            tempDirStream.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    logger.warn("Unable to delete temporary log file {}", path, e);
+                }
+            });
         } catch (IOException e) {
-            logger.warn("Unable to delete temporary log files", e);
+            logger.warn("Unable to delete temporary log directory {}", tempDir, e);
         }
     }
 }

--- a/kura/test/org.eclipse.kura.web2.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.web2.test/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 Fragment-Host: org.eclipse.kura.web2
 Bundle-ActivationPolicy: lazy
 Import-Package: org.junit;version="[4.12.0,5.0.0)",
+ org.junit.rules;version="[4.12.0,5.0.0)",
  org.mockito;version="[4.0.0,5.0.0)",
  org.mockito.invocation;version="[4.0.0,5.0.0)",
  org.mockito.stubbing;version="[4.0.0,5.0.0)"

--- a/kura/test/org.eclipse.kura.web2.test/src/test/java/org/eclipse/kura/web/server/servlet/LogServletTest.java
+++ b/kura/test/org.eclipse.kura.web2.test/src/test/java/org/eclipse/kura/web/server/servlet/LogServletTest.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.server.servlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class LogServletTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private final LogServlet logServlet = new LogServlet();
+
+    /*
+     * uniqueEntryName
+     */
+
+    @Test
+    public void shouldKeepTheFileNameWhenThereIsNoCollision() {
+        Set<String> usedEntryNames = new HashSet<>();
+
+        assertEquals("kura.log", this.logServlet.uniqueEntryName(usedEntryNames, "kura.log"));
+        assertEquals("messages", this.logServlet.uniqueEntryName(usedEntryNames, "messages"));
+    }
+
+    @Test
+    public void shouldSuffixCollidingEntryNamesPreservingTheExtension() {
+        Set<String> usedEntryNames = new HashSet<>();
+
+        assertEquals("kura.log", this.logServlet.uniqueEntryName(usedEntryNames, "kura.log"));
+        assertEquals("kura_1.log", this.logServlet.uniqueEntryName(usedEntryNames, "kura.log"));
+        assertEquals("kura_2.log", this.logServlet.uniqueEntryName(usedEntryNames, "kura.log"));
+    }
+
+    @Test
+    public void shouldSuffixCollidingEntryNamesWithoutExtension() {
+        Set<String> usedEntryNames = new HashSet<>();
+
+        assertEquals("messages", this.logServlet.uniqueEntryName(usedEntryNames, "messages"));
+        assertEquals("messages_1", this.logServlet.uniqueEntryName(usedEntryNames, "messages"));
+    }
+
+    @Test
+    public void shouldNotMistakeALeadingDotForAnExtension() {
+        Set<String> usedEntryNames = new HashSet<>();
+
+        assertEquals(".hidden", this.logServlet.uniqueEntryName(usedEntryNames, ".hidden"));
+        assertEquals(".hidden_1", this.logServlet.uniqueEntryName(usedEntryNames, ".hidden"));
+    }
+
+    /*
+     * buildArchiveName / sanitizeForFileName
+     */
+
+    @Test
+    public void shouldNameTheArchiveAfterTheDeviceAndTheMoment() {
+        LocalDateTime timestamp = LocalDateTime.of(2026, 8, 18, 15, 26, 7);
+
+        assertEquals("Kura_Logs_gateway-01_20260818-152607",
+                this.logServlet.buildArchiveName("gateway-01", timestamp).replace(".zip", ""));
+    }
+
+    @Test
+    public void shouldOmitTheDeviceNameWhenItIsMissing() {
+        LocalDateTime timestamp = LocalDateTime.of(2026, 8, 18, 15, 26, 7);
+
+        assertEquals("Kura_Logs_20260818-152607.zip", this.logServlet.buildArchiveName(null, timestamp));
+        assertEquals("Kura_Logs_20260818-152607.zip", this.logServlet.buildArchiveName("   ", timestamp));
+        assertEquals("Kura_Logs_20260818-152607.zip", this.logServlet.buildArchiveName("///", timestamp));
+    }
+
+    @Test
+    public void shouldKeepTheArchiveNameSafeForAFileSystemAndForTheHeader() {
+        LocalDateTime timestamp = LocalDateTime.of(2026, 8, 18, 15, 26, 7);
+
+        assertEquals("Kura_Logs_my_device_20260818-152607.zip",
+                this.logServlet.buildArchiveName("my/device", timestamp));
+        assertEquals("Kura_Logs_dev_rm_-rf_20260818-152607.zip",
+                this.logServlet.buildArchiveName("dev\"; rm -rf /", timestamp));
+        assertEquals("Kura_Logs_ESF_GW_20260818-152607.zip",
+                this.logServlet.buildArchiveName("ESF GW", timestamp));
+    }
+
+    @Test
+    public void shouldCapAVeryLongDeviceName() {
+        String longName = this.logServlet.sanitizeForFileName(
+                "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij");
+
+        assertEquals(40, longName.length());
+        assertEquals("abcdefghijabcdefghijabcdefghijabcdefghij", longName);
+    }
+
+    /*
+     * zipFiles
+     */
+
+    @Test
+    public void shouldZipAllProvidedFiles() throws IOException {
+        List<File> files = new ArrayList<>();
+        files.add(givenFile(this.folder.getRoot(), "kura.log", "kura content"));
+        files.add(givenFile(this.folder.getRoot(), "messages", "system content"));
+
+        Map<String, String> entries = whenFilesAreZipped(files);
+
+        assertEquals(2, entries.size());
+        assertEquals("kura content", entries.get("kura.log"));
+        assertEquals("system content", entries.get("messages"));
+    }
+
+    @Test
+    public void shouldSkipUnreadableFilesAndStillProduceAValidArchive() throws IOException {
+        File missing = new File(this.folder.getRoot(), "rotated.log");
+
+        List<File> files = new ArrayList<>();
+        files.add(givenFile(this.folder.getRoot(), "kura.log", "kura content"));
+        files.add(missing);
+        files.add(givenFile(this.folder.getRoot(), "messages", "system content"));
+
+        Map<String, String> entries = whenFilesAreZipped(files);
+
+        assertFalse(missing.exists());
+        assertEquals(2, entries.size());
+        assertEquals("kura content", entries.get("kura.log"));
+        assertEquals("system content", entries.get("messages"));
+    }
+
+    @Test
+    public void shouldDeduplicateEntryNamesComingFromDifferentDirectories() throws IOException {
+        File firstDir = this.folder.newFolder("var-log");
+        File secondDir = this.folder.newFolder("opt-log");
+
+        List<File> files = new ArrayList<>();
+        files.add(givenFile(firstDir, "kura.log", "first content"));
+        files.add(givenFile(secondDir, "kura.log", "second content"));
+
+        Map<String, String> entries = whenFilesAreZipped(files);
+
+        assertEquals(2, entries.size());
+        assertEquals("first content", entries.get("kura.log"));
+        assertEquals("second content", entries.get("kura_1.log"));
+    }
+
+    @Test
+    public void shouldProduceAValidArchiveWhenThereIsNothingToZip() throws IOException {
+        Map<String, String> entries = whenFilesAreZipped(new ArrayList<File>());
+
+        assertTrue(entries.isEmpty());
+    }
+
+    /*
+     * createPrivateTempDirectory / deleteTempDirectory
+     */
+
+    @Test
+    public void shouldCreateDistinctPrivateTemporaryDirectories() throws IOException {
+        Assume.assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+
+        Path first = this.logServlet.createPrivateTempDirectory();
+        Path second = this.logServlet.createPrivateTempDirectory();
+
+        try {
+            assertFalse(first.equals(second));
+            assertTrue(Files.isDirectory(first));
+            assertEquals(PosixFilePermissions.fromString("rwx------"), Files.getPosixFilePermissions(first));
+        } finally {
+            this.logServlet.deleteTempDirectory(first);
+            this.logServlet.deleteTempDirectory(second);
+        }
+    }
+
+    @Test
+    public void shouldDeleteTheTemporaryDirectoryWithItsContent() throws IOException {
+        Path tempDir = this.logServlet.createPrivateTempDirectory();
+        Files.write(tempDir.resolve("kura_journal.log"), "journal".getBytes(StandardCharsets.UTF_8));
+        Files.createDirectory(tempDir.resolve("nested"));
+        Files.write(tempDir.resolve("nested").resolve("Kura_Logs.zip"), new byte[] { 1, 2, 3 });
+
+        this.logServlet.deleteTempDirectory(tempDir);
+
+        assertFalse(Files.exists(tempDir));
+    }
+
+    @Test
+    public void shouldTolerateANullOrAlreadyDeletedTemporaryDirectory() throws IOException {
+        Path tempDir = this.logServlet.createPrivateTempDirectory();
+        Files.delete(tempDir);
+
+        this.logServlet.deleteTempDirectory(null);
+        this.logServlet.deleteTempDirectory(tempDir);
+
+        assertFalse(Files.exists(tempDir));
+    }
+
+    /*
+     * utilities
+     */
+
+    private File givenFile(File parent, String name, String content) throws IOException {
+        File file = new File(parent, name);
+        Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+
+    private Map<String, String> whenFilesAreZipped(List<File> files) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            this.logServlet.zipFiles(zos, files);
+        }
+
+        Map<String, String> entries = new HashMap<>();
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                ByteArrayOutputStream entryContent = new ByteArrayOutputStream();
+                byte[] buffer = new byte[64];
+                int read;
+                while ((read = zis.read(buffer)) != -1) {
+                    entryContent.write(buffer, 0, read);
+                }
+                entries.put(entry.getName(), new String(entryContent.toByteArray(), StandardCharsets.UTF_8));
+            }
+        }
+
+        return entries;
+    }
+}


### PR DESCRIPTION
Backport to `release-5.6.0` of eclipse-kura/kura-management-ui#51. The only adaptation is `jakarta.servlet` → `javax.servlet`; `LogTabUi` is identical on both branches and was taken verbatim.

## What was wrong

`LogServlet` wrote its journal dumps to the fixed paths `/tmp/kura_journal.log` and `/tmp/system_journal.log`, so two users downloading the system logs at the same time truncated and deleted each other's files. Independently of that, a single unreadable file (a rotated log, or a journal dump removed by a concurrent request) aborted the whole archive, and two directories in `kura.log.download.sources` holding files with the same name raised a `ZipException`. Each of these produced an empty download, no completion cookie — so the browser kept spinning for five minutes — and the same opaque `Unable to create zip file containing log resources` warning, with the exception discarded.

## Description of the solution adopted

Server side:

- every request assembles its logs in its own private temporary directory (`Files.createTempDirectory`, `rwx------`), removed in a `finally` block;
- unreadable files are skipped with a warning instead of aborting the archive, and colliding entry names are deduplicated (`kura.log`, `kura_1.log`);
- the archive is assembled on disk rather than buffered whole in a `byte[]`;
- the completion cookie is sent on the failure paths too, and its nonce is validated before it becomes a cookie name;
- the downloaded file is named `Kura_Logs_<device>_<yyyyMMdd-HHmmss>.zip` instead of always `Kura_Logs.zip`;
- the caught exception is passed to the logger.

Client side, in `LogTabUi`:

- the download nonce is regenerated on every click instead of once per widget, so two downloads never share a completion cookie;
- the polling timer no longer reschedules itself after `cancel()`. It used to stay alive for the lifetime of the page and, every ~5 minutes, tear down the application-wide wait modal that any other long operation in the console also uses.