### PR TITLE
ci: fix version-uptick workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -34,19 +34,19 @@ jobs:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: '21'
 
-    - name: Install BOM POM
-      run: mvn -B -pl bom install -DskipTests
-      shell: bash
-
     - name: Get version
       id: get-version
-      run: "echo \"resolved-version=\
-        $(mvn
-          --file ./pom.xml
-          -Dexec.executable=echo
-          -Dexec.args='${project.version}'
-          --quiet exec:exec --non-recursive
-        )\" >> \"${GITHUB_OUTPUT}\""
+      run: |
+        set -euo pipefail
+        version="$(python3 - <<'EOF'
+        import sys, xml.etree.ElementTree as ET
+        version = ET.parse("pom.xml").getroot().findtext("{http://maven.apache.org/POM/4.0.0}version")
+        if not version or not version.strip():
+            sys.exit("::error file=pom.xml::unable to read /project/version from the root pom")
+        print(version.strip())
+        EOF
+        )"
+        echo "version=${version}" >> "${GITHUB_OUTPUT}"
       shell: bash
 
     - name: Check file existence

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -80,7 +80,7 @@ jobs:
       run: |
         java -jar ${{ steps.download-changelog-cli.outputs.file }} \
         -fc "${{ github.event.inputs.starting_commit }}" \
-        -ex "{\"version\":\"${{ steps.get-version.outputs.resolved-version }}\"}" \
+        -ex "{\"version\":\"${{ steps.get-version.outputs.version }}\"}" \
         -t .github/release_notes_template/template.hbs \
         -hhf .github/release_notes_template/helper.hbs \
         -of ./distrib/RELEASE_NOTES.txt
@@ -107,8 +107,8 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
-        title: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
-        commit-message: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
-        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.resolved-version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
+        title: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
+        commit-message: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
+        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
         branch-suffix: timestamp
         token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -32,6 +32,12 @@ jobs:
       with:
         ref: ${{ github.event.inputs.target_branch }}
 
+    - name: Setup Java SDK
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
     - name: Download version upticker tool
       uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       with:
@@ -55,26 +61,25 @@ jobs:
         rm ./version-uptick-0.2.0-linux-x86_64
       shell: bash
 
+    - name: Install BOM POM
+      run: mvn -B -pl bom install -DskipTests
+
     - name: Get version
       id: get-version
-      run: |
-        set -euo pipefail
-        version="$(python3 - <<'EOF'
-        import sys, xml.etree.ElementTree as ET
-        version = ET.parse("pom.xml").getroot().findtext("{http://maven.apache.org/POM/4.0.0}version")
-        if not version or not version.strip():
-            sys.exit("::error file=pom.xml::unable to read /project/version from the root pom")
-        print(version.strip())
-        EOF
-        )"
-        echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      run: "echo \"resolved-version=\
+        $(mvn
+          --file ./pom.xml
+          -Dexec.executable=echo
+          -Dexec.args='${project.version}'
+          --quiet exec:exec --non-recursive
+        )\" >> \"${GITHUB_OUTPUT}\""
       shell: bash
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
-        title: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
-        commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
-        body: "Automated changes by _Version uptick automation_ action: automated uptick to ${{ steps.get-version.outputs.version }} version"
+        title: "chore: automated uptick to ${{ steps.get-version.outputs.resolved-version }}"
+        commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.resolved-version }}"
+        body: "Automated changes by _Version uptick automation_ action: automated uptick to ${{ steps.get-version.outputs.resolved-version }} version"
         branch-suffix: timestamp
         token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -57,9 +57,18 @@ jobs:
 
     - name: Get version
       id: get-version
-      uses: JActions/maven-version@aafa242403588c1c69d619b3cec9c2ff6abd57ac # v1.0.1
-      with:
-        pom: ./pom.xml
+      run: |
+        set -euo pipefail
+        version="$(python3 - <<'EOF'
+        import sys, xml.etree.ElementTree as ET
+        version = ET.parse("pom.xml").getroot().findtext("{http://maven.apache.org/POM/4.0.0}version")
+        if not version or not version.strip():
+            sys.exit("::error file=pom.xml::unable to read /project/version from the root pom")
+        print(version.strip())
+        EOF
+        )"
+        echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      shell: bash
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -32,12 +32,6 @@ jobs:
       with:
         ref: ${{ github.event.inputs.target_branch }}
 
-    - name: Setup Java SDK
-      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-
     - name: Download version upticker tool
       uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       with:
@@ -61,25 +55,26 @@ jobs:
         rm ./version-uptick-0.2.0-linux-x86_64
       shell: bash
 
-    - name: Install BOM POM
-      run: mvn -B -pl bom install -DskipTests
-
     - name: Get version
       id: get-version
-      run: "echo \"resolved-version=\
-        $(mvn
-          --file ./pom.xml
-          -Dexec.executable=echo
-          -Dexec.args='${project.version}'
-          --quiet exec:exec --non-recursive
-        )\" >> \"${GITHUB_OUTPUT}\""
+      run: |
+        set -euo pipefail
+        version="$(python3 - <<'EOF'
+        import sys, xml.etree.ElementTree as ET
+        version = ET.parse("pom.xml").getroot().findtext("{http://maven.apache.org/POM/4.0.0}version")
+        if not version or not version.strip():
+            sys.exit("::error file=pom.xml::unable to read /project/version from the root pom")
+        print(version.strip())
+        EOF
+        )"
+        echo "version=${version}" >> "${GITHUB_OUTPUT}"
       shell: bash
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
-        title: "chore: automated uptick to ${{ steps.get-version.outputs.resolved-version }}"
-        commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.resolved-version }}"
-        body: "Automated changes by _Version uptick automation_ action: automated uptick to ${{ steps.get-version.outputs.resolved-version }} version"
+        title: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
+        commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
+        body: "Automated changes by _Version uptick automation_ action: automated uptick to ${{ steps.get-version.outputs.version }} version"
         branch-suffix: timestamp
         token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR:
- Fixes the broken `version-uptick` workflow
- Refactors `release-notes` workflow to share the same get version method for consistency