### PR TITLE
ci: use wildcard in validate-metatypes workflow

### DIFF
--- a/.github/workflows/validate-metatypes.yml
+++ b/.github/workflows/validate-metatypes.yml
@@ -3,7 +3,7 @@ name: Validate metatypes
 on:
   pull_request:
     branches:
-      - release-5.6.0
+      - release-5.*
     types:
       - opened
       - reopened


### PR DESCRIPTION
Match all 5.X branches when running the `validate-metatypes` worflow.