### PR TITLE
fix(distrib): disable OSGi console by default

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -337,7 +337,6 @@ if [ -z "$KURA_RUNNING" ] ; then
         -Djava.security.policy=${DIR}/framework/jdk.dio.policy \
         -Djdk.dio.registry=${DIR}/framework/jdk.dio.properties \
         -Djdk.tls.trustNameService=true \
-        -Dosgi.console= \
         -Declipse.consoleLog=true \
         -jar ${DIR}/plugins/org.eclipse.equinox.launcher_${org.eclipse.equinox.launcher.version}.jar \
         -configuration  /tmp/.kura/configuration
@@ -449,7 +448,6 @@ if [ -z "$KURA_RUNNING" ] ; then
         -Djava.security.policy=${DIR}/framework/jdk.dio.policy \
         -Djdk.dio.registry=${DIR}/framework/jdk.dio.properties \
         -Djdk.tls.trustNameService=true \
-        -Dosgi.console= \
         -Declipse.consoleLog=true \
         -jar ${DIR}/plugins/org.eclipse.equinox.launcher_${org.eclipse.equinox.launcher.version}.jar \
         -configuration /tmp/.kura/configuration &

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -337,7 +337,7 @@ if [ -z "$KURA_RUNNING" ] ; then
         -Djava.security.policy=${DIR}/framework/jdk.dio.policy \
         -Djdk.dio.registry=${DIR}/framework/jdk.dio.properties \
         -Djdk.tls.trustNameService=true \
-        -Dosgi.console \
+        -Dosgi.console= \
         -Declipse.consoleLog=true \
         -jar ${DIR}/plugins/org.eclipse.equinox.launcher_${org.eclipse.equinox.launcher.version}.jar \
         -configuration  /tmp/.kura/configuration
@@ -449,7 +449,7 @@ if [ -z "$KURA_RUNNING" ] ; then
         -Djava.security.policy=${DIR}/framework/jdk.dio.policy \
         -Djdk.dio.registry=${DIR}/framework/jdk.dio.properties \
         -Djdk.tls.trustNameService=true \
-        -Dosgi.console=5002 \
+        -Dosgi.console= \
         -Declipse.consoleLog=true \
         -jar ${DIR}/plugins/org.eclipse.equinox.launcher_${org.eclipse.equinox.launcher.version}.jar \
         -configuration /tmp/.kura/configuration &


### PR DESCRIPTION
Disable OSGi console by default.

I left the `start_kura_debug.sh` script as-is given that the console might be useful in that scenario and the user needs to opt in.

I left Docker containers untouched given that, similarly, the port needs to be exposed manually by the user.

Tested on Raspberry Pi