### PR TITLE
ci(Jenkinsfile): exclude duplicated cloud connection classes from Sonar CPD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ node {
                                 ${analysisParameters} \
                                 -Dsonar.projectKey=org.eclipse.kura:kura \
                                 -Dsonar.exclusions=**/*.xml,**/*.yml,test-util/**/*,emulator/**/*,com.codeminders.hidapi-parent/**/*,org.moka7/**/*,org.eclipse.soda.dk.comm-parent/**/*,org.eclipse.kura.sun.misc/**/*,log4j2-api-config/**/*,org.usb4java/**/*,usb4java-javax/**/* \
-                                -Dsonar.cpd.exclusions=**/*Metatype.java,**/*Options.java \
+                                -Dsonar.cpd.exclusions=**/*Metatype.java,**/*Options.java,**/LifeCyclePayloadBuilder.java,**/CloudServiceImpl.java,**/CloudConnectionManagerImpl.java,**/CloudPublisherImpl.java,**/DefaultCloudConnectionFactory.java,**/RawMqttCloudConnectionFactory.java \
                                 -Dsonar.test.exclusions=**/*
                         """
                     }


### PR DESCRIPTION
This change adds those classes to `sonar.cpd.exclusions` so their known duplication no longer counts against the new-code gate. It only affects the copy-paste detection: the classes are still analysed for issues, coverage and security.