### PR TITLE
build: do not emit osgi.service requirements from DS annotations

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/bnd.bnd
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/bnd.bnd
@@ -26,4 +26,4 @@ Bundle-ActivationPolicy: lazy
 -includeresource: \
     about.html,\
     about_files=about_files/
--dsannotations-options: inherit
+-dsannotations-options: inherit,norequirements

--- a/kura/org.eclipse.kura.core.configuration/bnd.bnd
+++ b/kura/org.eclipse.kura.core.configuration/bnd.bnd
@@ -34,6 +34,6 @@ Export-Package: \
 -includeresource: \
     about.html,\
     about_files=about_files/
--dsannotations-options: inherit
+-dsannotations-options: inherit,norequirements
 
 Service-Component: OSGI-INF/*.xml

--- a/kura/org.eclipse.kura.core.keystore/bnd.bnd
+++ b/kura/org.eclipse.kura.core.keystore/bnd.bnd
@@ -46,4 +46,4 @@ Export-Package: \
 -includeresource: \
     about_files=about_files/,\
     about.html
--dsannotations-options: inherit
+-dsannotations-options: inherit,norequirements

--- a/kura/org.eclipse.kura.rest.keystore.provider/bnd.bnd
+++ b/kura/org.eclipse.kura.rest.keystore.provider/bnd.bnd
@@ -26,4 +26,4 @@ Bundle-ActivationPolicy: lazy
 -includeresource: \
     about.html,\
     about_files=about_files/
--dsannotations-options: inherit
+-dsannotations-options: inherit,norequirements

--- a/kura/org.eclipse.kura.rest.security.provider/bnd.bnd
+++ b/kura/org.eclipse.kura.rest.security.provider/bnd.bnd
@@ -16,4 +16,4 @@ Bundle-ActivationPolicy: lazy
 -includeresource: \
     about.html,\
     about_files=about_files/
--dsannotations-options: inherit
+-dsannotations-options: inherit,norequirements

--- a/kura/org.eclipse.kura.rest.tamper.detection.provider/bnd.bnd
+++ b/kura/org.eclipse.kura.rest.tamper.detection.provider/bnd.bnd
@@ -18,4 +18,4 @@ Bundle-ActivationPolicy: lazy
 -includeresource: \
     about.html,\
     about_files=about_files/
--dsannotations-options: inherit
+-dsannotations-options: inherit,norequirements

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -148,6 +148,17 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Do not emit "Require-Capability: osgi.service;...;effective:=active" for DS
+                         references. The OSGi framework ignores them at runtime and Kura's own bnd
+                         resolution uses -resolve.effective: resolve, but p2/Tycho does not honor the
+                         effective directive and treats them as hard requirements, which breaks the
+                         dependency resolution of every Tycho/PDE project consuming Kura bundles
+                         (e.g. an unsatisfiable osgi.service requirement on DeploymentAdmin). -->
+                    <bnd><![CDATA[
+                        -dsannotations-options: norequirements
+                    ]]></bnd>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
After the Tycho to bnd migration every DS `@Reference` adds a `Require-Capability: osgi.service;...;effective:=active` header to the bundle manifests. The OSGi framework ignores `effective:=active` requirements at runtime and the Kura integration tests already resolve with `-resolve.effective: resolve`, but p2 (and therefore Tycho) does not understand the `effective` directive and treats them as mandatory ([eclipse-tycho/tycho#5448](https://github.com/eclipse-tycho/tycho/issues/5448)). As a result every Tycho/PDE project that consumes the Kura 6 snapshots fails dependency resolution, for example:

```
Missing requirement: org.eclipse.kura.core.inventory 2.0.0.202609030736 requires 'osgi.service; (objectClass=org.osgi.service.deploymentadmin.DeploymentAdmin)' but it could not be found
```

**Description of the solution adopted:** `-dsannotations-options: norequirements` is set once in the bnd-maven-plugin configuration of `kura/pom.xml`, which the plugin merges into the instructions of every module, and added to the six `bnd.bnd` files that already override the option with `inherit`. The generated `Provide-Capability: osgi.service` headers, the `osgi.extender` requirement and the DS component descriptors are unchanged, so the manifests go back to the metadata contract of the Tycho-built bundles.