### PR TITLE
test: bridge the log4j API into slf4j-simple for the unit tests

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -169,6 +169,11 @@
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
                 <version>${commons-fileupload.version}</version>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -133,6 +133,11 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The unit tests hosted in the bundles run with `slf4j-simple` as their only logging provider, but `org.eclipse.kura.api` depends on `log4j-api` and `KuraException`, `KuraRuntimeException`, `Cloudlet` and `CommConnectionImpl` log through it. Every surefire run therefore prints `Log4j API could not find a logging provider` and whatever those classes log is lost.

This adds a test-scoped `log4j-to-slf4j` bridge next to `slf4j-simple` in `kura/pom.xml` (version managed in the bom at `${log4j.version}`), so the log4j 2 API output reaches the same sink. Test scope only: nothing changes in the bundle manifests or in the bnd-testing OSGi runtime, which keeps logging through log4j2.