### PR TITLE
build: use inputEncoding parameter for maven-checkstyle-plugin

### DIFF
--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -198,7 +198,7 @@
                         <id>checkstyle-validation</id>
                         <phase>process-sources</phase>
                         <configuration>
-                            <encoding>UTF-8</encoding>
+                            <inputEncoding>UTF-8</inputEncoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>
                             <linkXRef>false</linkXRef>


### PR DESCRIPTION
maven-checkstyle-plugin 3.6.0 does not accept the `<encoding>` configuration element anymore: `encoding` is only the user-property name of the `inputEncoding` parameter, so every module logged

```
[WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.6.0:check (checkstyle-validation)'
```

and the configured value was silently ignored (falling back to `project.build.sourceEncoding`). This renames the element to `inputEncoding`, which removes the warning and makes the UTF-8 setting effective again.