### PR TITLE
fix(http.server.manager): retry opening a connector whose port is still in use

### DIFF
--- a/kura/org.eclipse.kura.http.server.manager/pom.xml
+++ b/kura/org.eclipse.kura.http.server.manager/pom.xml
@@ -27,7 +27,7 @@
 
 	<properties>
 		<kura.basedir>${project.basedir}/..</kura.basedir>
-		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../../test/org.eclipse.kura.http.server.manager.test/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+		<sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml,${project.basedir}/../../test/org.eclipse.kura.http.server.manager.test/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 
 
@@ -94,5 +94,23 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/ConnectorOpener.java
+++ b/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/ConnectorOpener.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.http.server.manager;
+
+import java.io.IOException;
+
+import org.eclipse.jetty.server.ServerConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Opens a Jetty connector, retrying while its port is still held by a server instance that is
+ * being stopped: when the HttpService is restarted, the new Jetty instance may try to bind its
+ * ports a few milliseconds before the previous one has released them.
+ */
+final class ConnectorOpener {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConnectorOpener.class);
+
+    private ConnectorOpener() {
+    }
+
+    static void open(final ServerConnector connector, final int attempts, final long retryDelayMillis)
+            throws IOException {
+        IOException failure = null;
+        for (int attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                connector.open();
+                return;
+            } catch (final IOException e) {
+                failure = e;
+                if (attempt < attempts) {
+                    logger.warn("Unable to open {}, retrying in {} ms (attempt {} of {})", connector, retryDelayMillis,
+                            attempt, attempts);
+                    sleep(retryDelayMillis, e);
+                }
+            }
+        }
+        throw failure;
+    }
+
+    private static void sleep(final long millis, final IOException failure) throws IOException {
+        try {
+            Thread.sleep(millis);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw failure;
+        }
+    }
+}

--- a/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/JettyServerHolder.java
+++ b/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/JettyServerHolder.java
@@ -71,6 +71,11 @@ public class JettyServerHolder {
 
     private static final Logger logger = LoggerFactory.getLogger(JettyServerHolder.class);
 
+    // on a restart the new instance can try to bind its ports before the stopping instance has
+    // released them: give it a few attempts instead of running without the connector
+    private static final int CONNECTOR_OPEN_ATTEMPTS = 5;
+    private static final long CONNECTOR_OPEN_RETRY_DELAY_MS = 200;
+
     private DeflaterPool deflaterPool = new DeflaterPool(CompressionPool.DEFAULT_CAPACITY, Deflater.BEST_COMPRESSION,
             true);
 
@@ -177,7 +182,7 @@ public class JettyServerHolder {
 
     private void addConnector(ServerConnector httpConnector) {
         try {
-            httpConnector.open();
+            ConnectorOpener.open(httpConnector, CONNECTOR_OPEN_ATTEMPTS, CONNECTOR_OPEN_RETRY_DELAY_MS);
             this.server.addConnector(httpConnector);
         } catch (IOException e) {
             logger.error("Unable to start a connector {}", httpConnector, e);

--- a/kura/org.eclipse.kura.http.server.manager/src/test/java/org/eclipse/kura/http/server/manager/ConnectorOpenerTest.java
+++ b/kura/org.eclipse.kura.http.server.manager/src/test/java/org/eclipse/kura/http/server/manager/ConnectorOpenerTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.http.server.manager;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.Test;
+
+public class ConnectorOpenerTest {
+
+    private static final int ATTEMPTS = 3;
+    private static final long NO_DELAY = 0;
+
+    private final ServerConnector connector = mock(ServerConnector.class);
+    private final IOException portInUse = new IOException("Failed to bind to 0.0.0.0/0.0.0.0:8080");
+    private IOException failure;
+
+    @Test
+    public void shouldOpenTheConnectorAtTheFirstAttempt() throws IOException {
+        givenAConnectorWhosePortIsFree();
+
+        whenTheConnectorIsOpened();
+
+        thenNoFailureIsReported();
+        thenTheConnectorWasOpened(1);
+    }
+
+    @Test
+    public void shouldRetryWhileThePortIsStillInUse() throws IOException {
+        givenAConnectorWhosePortIsReleasedAfterFailures(2);
+
+        whenTheConnectorIsOpened();
+
+        thenNoFailureIsReported();
+        thenTheConnectorWasOpened(3);
+    }
+
+    @Test
+    public void shouldGiveUpAfterTheLastAttempt() throws IOException {
+        givenAConnectorWhosePortStaysInUse();
+
+        whenTheConnectorIsOpened();
+
+        thenTheLastFailureIsReported();
+        thenTheConnectorWasOpened(ATTEMPTS);
+    }
+
+    private void givenAConnectorWhosePortIsFree() throws IOException {
+        doNothing().when(this.connector).open();
+    }
+
+    private void givenAConnectorWhosePortIsReleasedAfterFailures(final int failures) throws IOException {
+        final AtomicInteger calls = new AtomicInteger();
+        doAnswer(invocation -> {
+            if (calls.incrementAndGet() <= failures) {
+                throw this.portInUse;
+            }
+            return null;
+        }).when(this.connector).open();
+    }
+
+    private void givenAConnectorWhosePortStaysInUse() throws IOException {
+        doThrow(this.portInUse).when(this.connector).open();
+    }
+
+    private void whenTheConnectorIsOpened() {
+        try {
+            ConnectorOpener.open(this.connector, ATTEMPTS, NO_DELAY);
+        } catch (final IOException e) {
+            this.failure = e;
+        }
+    }
+
+    private void thenNoFailureIsReported() {
+        assertNull(this.failure);
+    }
+
+    private void thenTheLastFailureIsReported() {
+        assertNotNull(this.failure);
+        assertSame(this.portInUse, this.failure);
+    }
+
+    private void thenTheConnectorWasOpened(final int times) throws IOException {
+        verify(this.connector, times(times)).open();
+    }
+}


### PR DESCRIPTION
When the `HttpService` is restarted (its configuration is deleted and recreated by a configuration update, or a keystore change triggers the deferred restart) the new Jetty instance is started right after the old one is asked to stop, and the two run on different single-thread executors. On slow machines the new instance can try to bind its ports a few milliseconds before the previous instance has released them. `JettyServerHolder.addConnector` then logged

```
ERROR o.e.k.h.s.m.JettyServerHolder - Unable to start a connector ServerConnector@...{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
java.io.IOException: Failed to bind to 0.0.0.0/0.0.0.0:8080
Caused by: java.net.BindException: Address already in use
```

and started the server without that connector, so the port stayed closed until the next restart. The Eclipse CI agents hit it in four consecutive builds of #6377 (`HttpServiceTest.shouldOpenHttpPorts`, `shouldSupportRevocation` and the whole `ConfigurationRestServiceTest` failing with `Port 8080 not open`); in the logs the old connector is reported stopped 12 ms before the failed bind, with no other listener on the port.

This PR opens the connectors through a small `ConnectorOpener` helper that retries a busy port a few times (5 attempts, 200 ms apart) before giving up with the same error as before, and covers the helper with a unit test (first attempt succeeds, port released after some failures, port never released). No behaviour change when the port is free.
