### PR TITLE
fix(test-util): export the test utility packages at their own versions

### DIFF
--- a/kura/test-util/org.eclipse.kura.core.testutil/bnd.bnd
+++ b/kura/test-util/org.eclipse.kura.core.testutil/bnd.bnd
@@ -38,13 +38,13 @@ Import-Package: \
     javax.net.ssl,\
     *
 Export-Package: \
-    org.eclipse.kura.core.testutil;version="6.0.0",\
-    org.eclipse.kura.core.testutil.event;version="6.0.0",\
-    org.eclipse.kura.core.testutil.http;version="6.0.0",\
-    org.eclipse.kura.core.testutil.json;version="6.0.0",\
-    org.eclipse.kura.core.testutil.pki;version="6.0.0",\
-    org.eclipse.kura.core.testutil.requesthandler;version="6.0.0",\
-    org.eclipse.kura.core.testutil.service;version="6.0.0"
+    org.eclipse.kura.core.testutil;version="1.0.0",\
+    org.eclipse.kura.core.testutil.event;version="1.0.0",\
+    org.eclipse.kura.core.testutil.http;version="1.0.1",\
+    org.eclipse.kura.core.testutil.json;version="1.0.0",\
+    org.eclipse.kura.core.testutil.pki;version="1.2.0",\
+    org.eclipse.kura.core.testutil.requesthandler;version="2.0.0",\
+    org.eclipse.kura.core.testutil.service;version="1.0.0"
 -includeresource: \
     about.html,\
     about_files=about_files/

--- a/kura/test-util/org.eclipse.kura.test/bnd.bnd
+++ b/kura/test-util/org.eclipse.kura.test/bnd.bnd
@@ -16,7 +16,7 @@ Import-Package: \
     org.slf4j;version="1.6.4",\
     *
 Export-Package: \
-    org.eclipse.kura.test.annotation;version="6.0.0"
+    org.eclipse.kura.test.annotation;version="1.0.0"
 -includeresource: \
     about.html,\
     about_files=about_files/

--- a/kura/test-util/org.eclipse.kura.util.wire.test/bnd.bnd
+++ b/kura/test-util/org.eclipse.kura.util.wire.test/bnd.bnd
@@ -17,7 +17,7 @@ Import-Package: \
     org.slf4j;version="1.7.25",\
     *
 Export-Package: \
-    org.eclipse.kura.util.wire.test;version="6.0.0"
+    org.eclipse.kura.util.wire.test;version="1.2.0"
 -includeresource: \
     about.html,\
     about_files=about_files/


### PR DESCRIPTION
The bnd migration exported every package of `org.eclipse.kura.core.testutil`, `org.eclipse.kura.util.wire.test` and `org.eclipse.kura.test` at the bundle version (`6.0.0`) instead of the package versions the Tycho manifests carried in 5.6.2 (`1.0.0`/`1.2.0`, `1.1.0`, `1.0.0`). A consumer built against the 5.6 exports (`Import-Package: org.eclipse.kura.core.testutil;version="[1.0,2.0)"`) no longer resolves against Kura 6, and the jump hides the real evolution of those packages.

This PR restores the manifest versions and bumps only the packages that changed since `KURA_5.6.2_RELEASE`, following semantic versioning:

| Package | 5.6.2 | now | reason |
|---|---|---|---|
| `org.eclipse.kura.core.testutil.requesthandler` | 1.2.0 | **2.0.0** | the public fields of `Transport.Response` (`status`, `body`, `restMethod`, `requestHandlerMethod`) became private |
| `org.eclipse.kura.core.testutil.http` | 1.0.0 | **1.0.1** | `TestServer` reimplemented on Jetty 12 / `jakarta.servlet`, same public API |
| `org.eclipse.kura.util.wire.test` | 1.1.0 | **1.2.0** | new public class `TestEmitterReceiverOptions` |
| `org.eclipse.kura.core.testutil`, `.event`, `.json`, `.pki`, `.service`, `org.eclipse.kura.test.annotation` | 1.0.0 / 1.2.0 / 1.0.0 | unchanged | same public API and implementation as in 5.6.2 |

The consumers' import ranges are generated by bnd from the exporter's version, so they follow automatically: rebuilt `org.eclipse.kura.rest.identity.provider.test` now imports `requesthandler;version="[2.0,3)"` and `service;version="[1.0,2)"` and its integration tests pass.
